### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ perl:
     - "5.20"
     - "5.18"
     - "5.16"
-    - "5.14"
 before_install: cpanm --quiet --notest Devel::CheckLib Test::More


### PR DESCRIPTION
Removed Perl 5.14 which is not supported by Zonemaster.