### PR TITLE
Remove explicit dependency on core module

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,6 @@ GetOptions(
 configure_requires 'Devel::CheckLib';
 configure_requires 'Module::Install' => 1.19;
 configure_requires 'Module::Install::XSUtil';
-requires 'MIME::Base64';
 test_requires 'JSON::PP';
 test_requires 'Test::Fatal';
 test_requires 'Test::More' => 1.302015;


### PR DESCRIPTION
[MIME::Base64](https://perldoc.perl.org/MIME/Base64.html) is a core module. We don't need to list those in our dependencies.