### PR TITLE
Make Travis not fail on everything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,9 @@ perl:
     - "5.20"
     - "5.16"
 
-# Install configure-time dependencies
-before_install: cpanm --quiet --notest Devel::CheckLib Module::Install Module::Install::XSUtil
+before_install:
+    # Install configure-time dependencies
+    - cpanm --quiet --notest Devel::CheckLib Module::Install Module::Install::XSUtil
+
+    # Install compile-time dependencies
+    - sudo apt-get install -y libidn11-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ perl:
     - "5.26"
     - "5.24"
     - "5.22"
-    - "5.20"
-    - "5.16"
 
 before_install:
     # Install configure-time dependencies

--- a/t/utils.t
+++ b/t/utils.t
@@ -15,7 +15,7 @@ SKIP: {
 
     my @names = sort $res->addr2name( '8.8.8.8' );
     $count = $res->addr2name( '8.8.8.8' );
-    is_deeply( [map {lc($_)} @names], ['google-public-dns-a.google.com.'], 'expected names' );
+    is_deeply( [map {lc($_)} @names], ['dns.google.'], 'expected names' );
     is( $count, 1, 'expected name count' );
 }
 


### PR DESCRIPTION
At the moment Travis for zonemaster-ldns is completely broken and we cannot verify and merge any PRs at all. There are multiple reasons for this. This PR fixes some of the problems and provides a work-around for the others. The work-around consists of disabling Travis for the two oldest Perl versions. An issue will be created to re-enable the temporarily disabled Travis tests.