### PR TITLE
Support for Ed25519

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ldns"]
 	path = ldns
-	url = https://git.nlnetlabs.nl/ldns
+	url = https://github.com/NLnetLabs/ldns.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: bionic
+
 env:
 - TEST_WITH_NETWORK=1
 
@@ -9,8 +11,15 @@ perl:
     - "5.22"
 
 before_install:
-    # Install configure-time dependencies
-    - cpanm --quiet --notest Devel::CheckLib Module::Install Module::Install::XSUtil
+    - sudo apt-get install -y libidn11-dev libldns-dev
+    - eval $(curl https://travis-perl.github.io/init)
+    - cpan-install Devel::CheckLib Module::Install Module::Install::XSUtil
+    - cpan-install --deps
 
-    # Install compile-time dependencies
-    - sudo apt-get install -y libidn11-dev
+install:
+    # --no-internal-ldns is faster
+    # --no-ed25519 is compatibile with the openssl we get
+    - cpanm --notest --configure-args="--no-ed25519 --no-internal-ldns" .
+
+script:
+    - prove -bl $(test-files)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,14 @@ perl:
     - "5.22"
 
 before_install:
-    - sudo apt-get install -y libidn11-dev libldns-dev
     - eval $(curl https://travis-perl.github.io/init)
-    - cpan-install Devel::CheckLib Module::Install Module::Install::XSUtil
-    - cpan-install --deps
+    - sudo apt-get install -y libidn11-dev libldns-dev
+    - cpan-install --deps Devel::CheckLib Module::Install Module::Install::XSUtil
 
 install:
     # --no-internal-ldns is faster
     # --no-ed25519 is compatibile with the openssl we get
-    - cpanm --notest --configure-args="--no-ed25519 --no-internal-ldns" .
+    - cpanm --verbose --notest --configure-args="--no-ed25519 --no-internal-ldns" .
 
 script:
     - prove -bl $(test-files)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
     - cpan-install --deps
 
 install:
-    - cpanm --verbose --notest --configure-args="--no-ed25519" .
+    - cpanm --verbose --notest --configure-args="--no-ed25519 --no-internal-ldns" .
 
 script:
     - prove -bl $(test-files)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,14 @@ perl:
 
 before_install:
     - eval $(curl https://travis-perl.github.io/init)
+
     - sudo apt-get install -y libidn11-dev libldns-dev
-    - cpan-install --deps Devel::CheckLib Module::Install Module::Install::XSUtil
+
+    - cpan-install Devel::CheckLib Module::Install Module::Install::XSUtil
+    - cpan-install --deps
 
 install:
-    # --no-internal-ldns is faster
-    # --no-ed25519 is compatibile with the openssl we get
-    - cpanm --verbose --notest --configure-args="--no-ed25519 --no-internal-ldns" .
+    - cpanm --verbose --notest --configure-args="--no-ed25519" .
 
 script:
     - prove -bl $(test-files)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,11 @@ perl:
 
 before_install:
     - eval $(curl https://travis-perl.github.io/init)
-
-    - sudo apt-get install -y libidn11-dev libldns-dev
-
-    - cpan-install Devel::CheckLib Module::Install Module::Install::XSUtil
-    - cpan-install --deps
+    - sudo apt-get install -y libidn11-dev
+    - cpan-install --deps Devel::CheckLib Module::Install Module::Install::XSUtil
 
 install:
-    - cpanm --verbose --notest --configure-args="--no-ed25519 --no-internal-ldns" .
+    - cpanm --verbose --notest --configure-args="--no-ed25519" .
 
 script:
     - prove -bl $(test-files)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,13 +14,13 @@ all_from 'lib/Zonemaster/LDNS.pm';
 repository 'https://github.com/zonemaster/zonemaster-ldns';
 bugtracker 'https://github.com/zonemaster/zonemaster-ldns/issues';
 
-my $opt_randomize     = 0;
 my $opt_idn           = 1;
 my $opt_internal_ldns = 1;
+my $opt_randomize     = 0;
 GetOptions(
-    'randomize!'     => \$opt_randomize,
     'idn!'           => \$opt_idn,
     'internal-ldns!' => \$opt_internal_ldns,
+    'randomize!'     => \$opt_randomize,
 );
 
 configure_requires 'Devel::CheckLib';
@@ -31,29 +31,37 @@ test_requires 'Test::Fatal';
 test_requires 'Test::More' => 1.302015;
 
 use_ppport 3.19;
-cc_libs 'crypto';
 cc_include_paths 'include';
 cc_src_paths 'src';
 
-if ( $opt_internal_ldns ) {
-    cc_libs '-Lldns/lib';
-    cc_include_paths 'ldns';
-    print "Feature internal ldns enabled\n";
-}
-else {
-    cc_libs 'ldns';
-    print "Feature internal ldns disabled\n";
-}
 
-my %assert_args = (
+# OpenSSL
+
+cc_libs 'crypto';
+cc_assert_lib(
     lib      => 'crypto',
     header   => 'openssl/crypto.h',
     function => 'if(SSLeay()) return 0; else return 1;'
 );
 
-cc_assert_lib %assert_args;
+
+# LDNS
+
+if ( $opt_internal_ldns ) {
+    print "Feature internal ldns enabled\n";
+    cc_libs '-Lldns/lib';
+    cc_include_paths 'ldns';
+}
+else {
+    print "Feature internal ldns disabled\n";
+    cc_libs 'ldns';
+}
+
+
+# IDN
 
 if ( $opt_idn ) {
+    print "Feature idn enabled\n";
     check_lib_or_exit(
         lib    => 'idn',
         header => 'idna.h',
@@ -62,19 +70,22 @@ if ( $opt_idn ) {
     );
     cc_libs 'idn';
     cc_define '-DWE_CAN_HAZ_IDN';
-    print "Feature idn enabled\n";
 }
 else {
     print "Feature idn disabled\n";
 }
 
+
+# Internals
+
 if ( $opt_randomize ) {
-    cc_define '-DRANDOMIZE';
     print "Feature randomized capitalization enabled\n";
+    cc_define '-DRANDOMIZE';
 }
 else {
     print "Feature randomized capitalization disabled\n";
 }
+
 
 sub MY::postamble {
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -45,9 +45,13 @@ cc_assert_lib(
     header   => 'openssl/crypto.h',
     function => 'if(SSLeay()) return 0; else return 1;'
 );
-
 if ( $opt_ed25519 ) {
     print "Feature Ed25519 enabled\n";
+    cc_assert_lib(
+        lib      => 'crypto',
+        header   => 'openssl/evp.h',
+        function => 'EVP_PKEY_ED25519; return 0;'
+    );
 }
 else {
     print "Feature Ed25519 disabled\n";
@@ -64,6 +68,14 @@ if ( $opt_internal_ldns ) {
 else {
     print "Feature internal ldns disabled\n";
     cc_libs 'ldns';
+    if ( $opt_ed25519 ) {
+        cc_assert_lib(
+            lib      => 'ldns',
+            header   => 'ldns/ldns.h',
+            ccflags  => '-DUSE_ED25519',
+            function => 'if(LDNS_ED25519) return 0; else return 1;'
+        );
+    }
 }
 
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -152,7 +152,9 @@ ldns/.libs/libldns.a: ldns/configure
 	make lib
 
 ldns/configure:
-	git submodule update --init
+	git submodule init
+	git submodule sync
+	git submodule update
 	cd ldns ; libtoolize -ci
 	cd ldns ; autoreconf -fi
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,10 +14,12 @@ all_from 'lib/Zonemaster/LDNS.pm';
 repository 'https://github.com/zonemaster/zonemaster-ldns';
 bugtracker 'https://github.com/zonemaster/zonemaster-ldns/issues';
 
+my $opt_ed25519       = 1;
 my $opt_idn           = 1;
 my $opt_internal_ldns = 1;
 my $opt_randomize     = 0;
 GetOptions(
+    'ed25519!'       => \$opt_ed25519,
     'idn!'           => \$opt_idn,
     'internal-ldns!' => \$opt_internal_ldns,
     'randomize!'     => \$opt_randomize,
@@ -43,6 +45,13 @@ cc_assert_lib(
     header   => 'openssl/crypto.h',
     function => 'if(SSLeay()) return 0; else return 1;'
 );
+
+if ( $opt_ed25519 ) {
+    print "Feature Ed25519 enabled\n";
+}
+else {
+    print "Feature Ed25519 disabled\n";
+}
 
 
 # LDNS
@@ -89,24 +98,6 @@ else {
 
 sub MY::postamble {
 
-    my $internal_ldns_make = <<'END_INTERNAL_LDNS';
-
-LDFROM += ldns/.libs/libldns.a
-
-config :: ldns/.libs/libldns.a
-
-ldns/.libs/libldns.a: ldns/configure
-	cd ldns ;\
-	./configure CFLAGS=-fPIC --disable-ldns-config --disable-dane ;\
-	make lib
-
-ldns/configure:
-	git submodule update --init
-	cd ldns ; libtoolize -ci
-	cd ldns ; autoreconf -fi
-
-END_INTERNAL_LDNS
-
     my $contributors_make = <<'END_CONTRIBUTORS';
 
 CONTRIBUTORS.txt:
@@ -119,9 +110,48 @@ CONTRIBUTORS.txt:
 
 END_CONTRIBUTORS
 
+    my $configure_flags_make = <<'END_CONFIGURE_FLAGS';
+
+CONFIGURE_FLAGS = --disable-ldns-config --disable-dane
+
+END_CONFIGURE_FLAGS
+
+    my $ed25519_make = <<'END_ED25519';
+
+CONFIGURE_FLAGS += --enable-ed25519
+
+END_ED25519
+
+    my $no_ed25519_make = <<'END_NO_ED25519';
+
+CONFIGURE_FLAGS += --disable-ed25519
+
+END_NO_ED25519
+
+    my $internal_ldns_make = <<'END_INTERNAL_LDNS';
+
+LDFROM += ldns/.libs/libldns.a
+
+config :: ldns/.libs/libldns.a
+
+ldns/.libs/libldns.a: ldns/configure
+	cd ldns ;\
+	./configure CFLAGS=-fPIC $(CONFIGURE_FLAGS) ;\
+	make lib
+
+ldns/configure:
+	git submodule update --init
+	cd ldns ; libtoolize -ci
+	cd ldns ; autoreconf -fi
+
+END_INTERNAL_LDNS
+
     my $postamble = '';
 
     $postamble .= $contributors_make;
+    $postamble .= $configure_flags_make;
+    $postamble .= $ed25519_make if $opt_ed25519;
+    $postamble .= $no_ed25519_make if !$opt_ed25519;
     $postamble .= $internal_ldns_make if $opt_internal_ldns;
 
     return $postamble;

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Initially this module was named Net::LDNS.
 ## Dependencies and compatibility
 
 Run-time dependencies:
- * `openssl` (>= 1.1.0 unless [Ed25519] is disabled)
+ * `openssl` (openssl >= 1.1.0 unless [Ed25519] is disabled)
  * `libidn` (if [IDN] is enabled)
- * `libldns` (if [Internal ldns] is disabled)
+ * `libldns` (if [Internal ldns] is disabled, libldns >= 1.7.1 unless [Ed25519] is disabled)
 
 Compile-time dependencies (only when installing from source):
  * `make`
@@ -100,6 +100,8 @@ commands.
 
 Enabled by default.
 Disabled with `--no-ed25519`
+
+Requires support for Ed25519 in both openssl and ldns.
 
 ### IDN
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Disabled with `--no-ed25519`
 
 Requires support for Ed25519 in both openssl and ldns.
 
+>
+> *Note:* Zonemaster Engine relies on this feature for its analysis when the
+> Ed25519 algorithm is being used.
+>
+
 ### IDN
 
 Enabled by default.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Initially this module was named Net::LDNS.
 ## Dependencies and compatibility
 
 Run-time dependencies:
- * `openssl` (openssl >= 1.1.0 unless [Ed25519] is disabled)
+ * `openssl` (openssl >= 1.1.1 unless [Ed25519] is disabled)
  * `libidn` (if [IDN] is enabled)
  * `libldns` (if [Internal ldns] is disabled; libldns >= 1.7.0, or libldns >= 1.7.1 if [Ed25519] is enabled)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Initially this module was named Net::LDNS.
 Run-time dependencies:
  * `openssl` (openssl >= 1.1.0 unless [Ed25519] is disabled)
  * `libidn` (if [IDN] is enabled)
- * `libldns` (if [Internal ldns] is disabled, libldns >= 1.7.1 unless [Ed25519] is disabled)
+ * `libldns` (if [Internal ldns] is disabled; libldns >= 1.7.0, or libldns >= 1.7.1 if [Ed25519] is enabled)
 
 Compile-time dependencies (only when installing from source):
  * `make`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Initially this module was named Net::LDNS.
 ## Dependencies and compatibility
 
 Run-time dependencies:
- * `openssl`
+ * `openssl` (>= 1.1.0 unless [Ed25519] is disabled)
  * `libidn` (if [IDN] is enabled)
  * `libldns` (if [Internal ldns] is disabled)
 
@@ -95,6 +95,11 @@ TEST_WITH_NETWORK=1 make test
 When installing from source, you can choose to enable or disable a number
 of optional features using command line options to the `perl Makefile.PL`
 commands.
+
+### Ed25519
+
+Enabled by default.
+Disabled with `--no-ed25519`
 
 ### IDN
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Disabled with `--no-ed25519`
 Requires support for Ed25519 in both openssl and ldns.
 
 >
-> *Note:* Zonemaster Engine relies on this feature for its analysis when the
-> Ed25519 algorithm is being used.
+> *Note:* Zonemaster Engine relies on this feature for its analysis when Ed25519
+> (algorithm 15) is being used in DNS records.
 >
 
 ### IDN


### PR DESCRIPTION
Fixes #51 and #84.

* Checks for Ed25519 support in dependencies by default.
* Makes it possible to work around the feature check by opting out of Ed25519 using a switch.
* Updates the internal version of ldns to include support for Ed25519.
* Updates Travis to work with lagging dependencies.

The other repositories will need updates to their Travis configurations as well because of the new feature checks. PRs for the other repositories have been prepared:
* zonemaster/zonemaster-engine#585
* zonemaster/zonemaster-cli#116
* zonemaster/zonemaster-backend#541

Moreover, these changes are blocked by zonemaster/zonemaster-backend#540.