### PR TITLE
Exclude more ldns files from MANIFEST

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -39,6 +39,7 @@
 ^ldns/doc/
 ^ldns/drill/
 ^ldns/examples/
+^ldns/.gitlab-ci.yml
 ^ldns/ldns/\.c-mode-rc.el$
 ^ldns/ldns/common\.h$
 ^ldns/ldns/config\.h$
@@ -56,6 +57,7 @@
 ^ldns/m4/ltversion\.m4$
 ^ldns/m4/lt~obsolete\.m4$
 ^ldns/makedist\.sh$
+^ldns/makewin.sh
 ^ldns/masterdont/
 ^ldns/packaging/fedora/ldns\.spec$
 ^ldns/packaging/ldns-config$
@@ -63,6 +65,7 @@
 ^ldns/packaging/libldns\.pc$
 ^ldns/pcat/
 ^ldns/test/
+^ldns/.travis.yml
 
 # Avoid C files generated from XS
 ^src/LDNS\.c$


### PR DESCRIPTION
Fixes some "Not in MANIFEST" warnings during `make distcheck`.