### PR TITLE
Updates in prepartion for release v2019.2

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,13 +1,24 @@
 Release history for Zonemaster component Zonemaster-LDNS
 
+
+3.0.0 2019-11-15
+
+ [API change]
+ - Support for Ed25519 (algorithm 15) added (#85, #51, #84)
+ - Requires libldns 1.7.0 or 1.7.1 (#85)
+
+ [Fixed]
+ - Make Travis not fail (#82)
+
+
 2.0.1 2019-05-21
 
 - Removed
-  - Ubuntu 14.04 is no longer supported
+  - Ubuntu 14.04 is no longer supported (#74)
 
 - Changed
-  - inc::Module::install is no longer bundled
-  - Dependency declarations have been cleaned up
+  - inc::Module::install is no longer bundled (#72)
+  - Dependency declarations have been cleaned up (#73)
 
 
 2.0.0 2019-01-25 (pre-release version)

--- a/Changes
+++ b/Changes
@@ -4,15 +4,17 @@ Release history for Zonemaster component Zonemaster-LDNS
 3.0.0 2019-11-15
 
  [API Change]
- - Requires libldns 1.7.0 or 1.7.1 (#85)
  - Requires OpenSSL 1.1.1 unless Ed25519 (algorithm 15)
    has been disabled
 
- [Changed]
+ [Features]
  - Support for Ed25519 (algorithm 15) added (#85, #51, #84)
+ - Updated to use libldns 1.7.0 or 1.7.1 (#85)
  
  [Fixed]
  - Make Travis not fail (#82)
+ - Exclude more ldns files from MANIFEST (#92)
+ - Fixing links and table of contents in main README.md (#94)
 
 
 2.0.1 2019-05-21

--- a/Changes
+++ b/Changes
@@ -3,7 +3,7 @@ Release history for Zonemaster component Zonemaster-LDNS
 
 3.0.0 2019-11-15
 
- [API change]
+ [Changed]
  - Support for Ed25519 (algorithm 15) added (#85, #51, #84)
  - Requires libldns 1.7.0 or 1.7.1 (#85)
 

--- a/Changes
+++ b/Changes
@@ -12,6 +12,7 @@ Release history for Zonemaster component Zonemaster-LDNS
  - Exclude more ldns files from MANIFEST (#92)
  - Fixing links and table of contents in main README.md (#94)
  - Exclude LDNS.bs from distribution file (#101, #95)
+ - Eliminated locale dependency from unit test (#102, #103)
  
 
 2.0.1 2019-05-21

--- a/Changes
+++ b/Changes
@@ -1,17 +1,18 @@
 Release history for Zonemaster component Zonemaster-LDNS
 
 
-2.1.0 2019-11-29
+2.1.0 2020-04-30
 
  [Features]
  - Updated to use libldns 1.7.0 or 1.7.1 (#85)
  - Support for Ed25519 (algorithm 15) added (#85, #51, #84)
+ - Allow specifying which OpenSSL library to use (#97)
  
  [Fixed]
- - Make Travis not fail (#82)
  - Exclude more ldns files from MANIFEST (#92)
  - Fixing links and table of contents in main README.md (#94)
-
+ - Exclude LDNS.bs from distribution file (#101, #95)
+ 
 
 2.0.1 2019-05-21
 

--- a/Changes
+++ b/Changes
@@ -3,10 +3,14 @@ Release history for Zonemaster component Zonemaster-LDNS
 
 3.0.0 2019-11-15
 
+ [API Change]
+ - Requires libldns 1.7.0 or 1.7.1 (#85)
+ - Requires OpenSSL 1.1.1 unless Ed25519 (algorithm 15)
+   has been disabled
+
  [Changed]
  - Support for Ed25519 (algorithm 15) added (#85, #51, #84)
- - Requires libldns 1.7.0 or 1.7.1 (#85)
-
+ 
  [Fixed]
  - Make Travis not fail (#82)
 

--- a/Changes
+++ b/Changes
@@ -1,15 +1,11 @@
 Release history for Zonemaster component Zonemaster-LDNS
 
 
-3.0.0 2019-11-15
-
- [API Change]
- - Requires OpenSSL 1.1.1 unless Ed25519 (algorithm 15)
-   has been disabled
+2.1.0 2019-11-29
 
  [Features]
- - Support for Ed25519 (algorithm 15) added (#85, #51, #84)
  - Updated to use libldns 1.7.0 or 1.7.1 (#85)
+ - Support for Ed25519 (algorithm 15) added (#85, #51, #84)
  
  [Fixed]
  - Make Travis not fail (#82)

--- a/lib/Zonemaster/LDNS.pm
+++ b/lib/Zonemaster/LDNS.pm
@@ -2,7 +2,7 @@ package Zonemaster::LDNS;
 
 use 5.014;
 
-our $VERSION = '2.0.1';
+our $VERSION = '2.1.0';
 
 use parent 'Exporter';
 our @EXPORT_OK = qw[to_idn has_idn ldns_version load_zonefile];


### PR DESCRIPTION
Updates for v2019.2 release:

* Changes file with all updates since last release
* Updated version (to v2.1.0) in `lib/Zonemaster/LDNS.pm`