### PR TITLE
Re-enable Travis for Perl 5.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ perl:
     - "5.26"
     - "5.24"
     - "5.22"
+    - "5.16"
 
 before_install:
     - eval $(curl https://travis-perl.github.io/init)


### PR DESCRIPTION
Resolves #83.

Perl 5.20 is not re-enabled here because none of our supported OSes use that version anymore.

Also #83 is scheduled for 2020.1 but I see no reason to wait.