### PR TITLE
Add Github PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Purpose
+
+This PR...
+
+## Context
+
+(e.g. Fixes #9999, Follow-up to #9999, etc.)
+
+## Changes
+
+...
+
+## How to test this PR
+
+...


### PR DESCRIPTION
## Purpose

Add a pull request template to Github. This helps us remember to provide important details when we make a pull request.

## Context

N/A

## Changes

A pull request template is added to the develop branch. This will not take effect immediately, but only after we merge the develop branch into the master branch after the release.

## How to test this PR

N/A