### PR TITLE
Use libidn2

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -99,12 +99,11 @@ else {
 if ( $opt_idn ) {
     print "Feature idn enabled\n";
     check_lib_or_exit(
-        lib    => 'idn',
-        header => 'idna.h',
+        lib    => 'idn2',
+        header => 'idn2.h',
         function =>
-          'if(strcmp(IDNA_ACE_PREFIX,"xn--")==0) return 0; else return 1;'
-    );
-    cc_libs 'idn';
+          'return IDN2_OK;');
+    cc_libs 'idn2';
     cc_define '-DWE_CAN_HAZ_IDN';
 }
 else {

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Initially this module was named Net::LDNS.
 
 Run-time dependencies:
  * `openssl` (openssl >= 1.1.1 unless [Ed25519] is disabled)
- * `libidn` (if [IDN] is enabled)
+ * `libidn2` (if [IDN] is enabled)
  * `libldns` (if [Internal ldns] is disabled; libldns >= 1.7.0, or
    libldns >= 1.7.1 if [Ed25519] is enabled)
 
@@ -139,7 +139,7 @@ Requires support for Ed25519 in both openssl and ldns.
 Enabled by default.
 Disable with `--no-idn`.
 
-If the IDN feature is enabled, the GNU `libidn` library will be used to
+If the IDN feature is enabled, the GNU `libidn2` library will be used to
 add a simple function that converts strings from Perl's internal encoding
 to IDNA domain name format.
 In order to convert strings from whatever encoding you have to Perl's

--- a/include/LDNS.h
+++ b/include/LDNS.h
@@ -13,7 +13,7 @@
 #include <ldns/ldns.h>
 
 #ifdef WE_CAN_HAZ_IDN
-#include <idna.h>
+#include <idn2.h>
 #endif
 
 /* ldns 1.6.17 does not have this in its header files, but it is in the published documentation and we need it */

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -18,8 +18,8 @@ to_idn(...)
 
             if (SvPOK(ST(i)))
             {
-               status = idna_to_ascii_8z(SvPVutf8_nolen(obj), &out, IDNA_ALLOW_UNASSIGNED);
-               if (status == IDNA_SUCCESS)
+               status = idn2_to_ascii_8z(SvPVutf8_nolen(obj), &out, IDN2_ALLOW_UNASSIGNED);
+               if (status == IDN2_OK)
                {
                   SV *new = newSVpv(out,0);
                   SvUTF8_on(new); /* We know the string is plain ASCII, so let Perl know too */
@@ -28,7 +28,7 @@ to_idn(...)
                }
                else
                {
-                  croak("Error: %s\n", idna_strerror(status));
+                  croak("Error: %s\n", idn2_strerror(status));
                }
             }
         }


### PR DESCRIPTION
## Purpose

Replace libidn with libidn2 following https://libidn.gitlab.io/libidn2/manual/libidn2.html#Converting-from-libidn.

## Context

#131 

## Changes

...

## How to test this PR

...


## Discussion

Old code was using [`IDNA_ALLOW_UNASSIGNED`](https://www.gnu.org/software/libidn/reference/libidn-idna.h.html#IDNA-ALLOW-UNASSIGNED:CAPS) in [`idna_to_ascii_8z`](https://www.gnu.org/software/libidn/reference/libidn-idna.h.html#idna-to-ascii-8z). Even if this flag exists in IDN2 ([`IDN2_ALLOW_UNASSIGNED`](https://www.gnu.org/software/libidn/libidn2/reference/libidn2-idn2.h.html#idn2-flags)) it seems it has been kept for compatibility reason and is unused. I haven't dig any further, but do we need to keep this flag, or should we update some logic in the code to keep the expected behavior we had with the old code?