### PR TITLE
Ignore DNSKEY RRs with incalculable key sizes

### DIFF
--- a/lib/Zonemaster/LDNS/Packet.pm
+++ b/lib/Zonemaster/LDNS/Packet.pm
@@ -26,6 +26,30 @@ sub data {
     return $self->wireformat;
 }
 
+sub answer {
+    my ( $self ) = @_;
+
+    my @records = $self->answer_unfiltered;
+
+    return @records;
+}
+
+sub authority {
+    my ( $self ) = @_;
+
+    my @records = $self->authority_unfiltered;
+
+    return @records;
+}
+
+sub additional {
+    my ( $self ) = @_;
+
+    my @records = $self->additional_unfiltered;
+
+    return @records;
+}
+
 1;
 
 =head1 NAME

--- a/lib/Zonemaster/LDNS/Packet.pm
+++ b/lib/Zonemaster/LDNS/Packet.pm
@@ -31,6 +31,12 @@ sub answer {
 
     my @records = $self->answer_unfiltered;
 
+    for ( my $i = $#records ; $i >= 0 ; --$i ) {
+        if ( $records[$i]->type() eq 'DNSKEY' && $records[$i]->keysize() == -1 ) {
+            splice @records, $i, 1;
+        }
+    }
+
     return @records;
 }
 

--- a/lib/Zonemaster/LDNS/RR/DNSKEY.pm
+++ b/lib/Zonemaster/LDNS/RR/DNSKEY.pm
@@ -15,6 +15,8 @@ sub keysize {
     if ( $algo == 1 || $algo == 5 || $algo == 7 || $algo == 8 || $algo == 10 ) {
 
         # Read first byte
+        return -1
+          if length $data < 1;
         my $byte = unpack( "c1", $data );
 
         my $remaining;
@@ -23,6 +25,8 @@ sub keysize {
         }
         else {
             # Read bytes 1 and 2 as big-endian
+            return -1
+              if length $data < 3;
             my $short = unpack( "x1s>1", $data );
 
             $remaining = length( $data ) - 3 - $short;
@@ -35,6 +39,8 @@ sub keysize {
     elsif ( $algo == 3 || $algo == 6 ) {
 
         # Read first byte (the T value)
+        return -1
+          if length $data < 1;
         return unpack( "c1", $data );
     }
 
@@ -42,6 +48,8 @@ sub keysize {
     elsif ( $algo == 2 ) {
 
         # Read bytes 4 and 5 as big-endian
+        return -1
+          if length $data < 6;
         return unpack( "x4s>1", $data );
     }
 
@@ -90,5 +98,6 @@ be available, depending on how you ldns library was compiled.
 
 The size of the key stored in the record. For RSA variants, it's the length in bits of the prime number. For DSA variants, it's the key's "T" value
 (see RFC2536). For DH, it's the value of the "prime length" field (and probably useless, since DH keys can't have signature records).
+If there is insufficient data in the public key field to calculate the key size, C<-1> is returned.
 
 =back

--- a/lib/Zonemaster/LDNS/RR/DNSKEY.pm
+++ b/lib/Zonemaster/LDNS/RR/DNSKEY.pm
@@ -32,7 +32,12 @@ sub keysize {
             $remaining = length( $data ) - 3 - $short;
         }
 
-        return 8 * $remaining;
+        if ( $remaining < 0 ) {
+            return -1;
+        }
+        else {
+            return 8 * $remaining;
+        }
     }
 
     # DSA variants

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1910,8 +1910,15 @@ rr_dnskey_keydata(obj)
     Zonemaster::LDNS::RR::DNSKEY obj;
     CODE:
     {
-        ldns_rdf *rdf = ldns_rr_rdf(obj,3);
-        RETVAL = newSVpvn((char*)ldns_rdf_data(rdf), ldns_rdf_size(rdf));
+        if (ldns_rr_rd_count(obj)>3)
+        {
+            ldns_rdf *rdf = ldns_rr_rdf(obj,3);
+            RETVAL = newSVpvn((char*)ldns_rdf_data(rdf), ldns_rdf_size(rdf));
+        }
+        else
+        {
+            RETVAL = newSVpvn("",0);
+        }
     }
     OUTPUT:
         RETVAL

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1837,50 +1837,6 @@ rr_ds_verify(obj,other)
 
 MODULE = Zonemaster::LDNS        PACKAGE = Zonemaster::LDNS::RR::DNSKEY           PREFIX=rr_dnskey_
 
-U32
-rr_dnskey_keysize(obj)
-    Zonemaster::LDNS::RR::DNSKEY obj;
-    CODE:
-    {
-        U8 algorithm = D_U8(obj,2);
-        ldns_rdf *rdf = ldns_rr_rdf(obj,3);
-        uint8_t *data = ldns_rdf_data(rdf);
-        size_t total = ldns_rdf_size(rdf);
-
-        /* RSA variants */
-        if(algorithm==1||algorithm==5||algorithm==7||algorithm==8||algorithm==10)
-        {
-            size_t ex_len;
-
-            if(data[0] == 0)
-            {
-                ex_len = 3+(U16)data[1];
-            }
-            else
-            {
-                ex_len = 1+(U8)data[0];
-            }
-            RETVAL = 8*(total-ex_len);
-        }
-        /* DSA variants */
-        else if(algorithm==3||algorithm==6)
-        {
-            RETVAL = (U8)data[0]; /* First octet is T value */
-        }
-        /* Diffie-Hellman */
-        else if(algorithm==2)
-        {
-            RETVAL = (U16)data[4];
-        }
-        /* No idea what this is */
-        else
-        {
-            RETVAL = 0;
-        }
-    }
-    OUTPUT:
-        RETVAL
-
 U16
 rr_dnskey_flags(obj)
     Zonemaster::LDNS::RR::DNSKEY obj;

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1064,7 +1064,7 @@ packet_timestamp(obj,...)
         RETVAL
 
 SV *
-packet_answer(obj)
+packet_answer_unfiltered(obj)
     Zonemaster::LDNS::Packet obj;
     PPCODE:
     {
@@ -1092,7 +1092,7 @@ packet_answer(obj)
     }
 
 SV *
-packet_authority(obj)
+packet_authority_unfiltered(obj)
     Zonemaster::LDNS::Packet obj;
     PPCODE:
     {
@@ -1120,7 +1120,7 @@ packet_authority(obj)
     }
 
 SV *
-packet_additional(obj)
+packet_additional_unfiltered(obj)
     Zonemaster::LDNS::Packet obj;
     PPCODE:
     {

--- a/t/rr.t
+++ b/t/rr.t
@@ -111,13 +111,16 @@ subtest 'DNSKEY' => sub {
 
     my $data = decode_base64( "BleFgAABAAEAAAAADW5sYWdyaWN1bHR1cmUCbmwAAAEAAcAMADAAAQAAAAAABAEBAwg=");
     my $p = Zonemaster::LDNS::Packet->new_from_wireformat( $data );
-    my ( $rr, @extra ) = $p->answer;
+    my ( $rr, @extra ) = $p->answer_unfiltered;
     eq_or_diff \@extra, [], "no extra RRs found";
     if ( !defined $rr ) {
         BAIL_OUT( "no RR found" );
     }
     is $rr->keydata, "", "we're able to extract the public key field even when it's empty";
     is $rr->keysize, -1, "insufficient data to calculate key size is reported as -1";
+
+    my ( @rrs ) = $p->answer;
+    eq_or_diff \@rrs, [], "DNSKEY record with empty public key is filtered out by answer()";
 };
 
 subtest 'RRSIG' => sub {

--- a/t/rr.t
+++ b/t/rr.t
@@ -117,6 +117,7 @@ subtest 'DNSKEY' => sub {
         BAIL_OUT( "no RR found" );
     }
     is $rr->keydata, "", "we're able to extract the public key field even when it's empty";
+    is $rr->keysize, -1, "insufficient data to calculate key size is reported as -1";
 };
 
 subtest 'RRSIG' => sub {

--- a/t/rr.t
+++ b/t/rr.t
@@ -2,6 +2,7 @@ use Test::More;
 use Test::Fatal;
 use Devel::Peek;
 use MIME::Base64;
+use Test::Differences;
 
 BEGIN { use_ok( 'Zonemaster::LDNS' ) }
 
@@ -107,6 +108,15 @@ subtest 'DNSKEY' => sub {
             ok( $rr->algorithm == 8 );
         }
     }
+
+    my $data = decode_base64( "BleFgAABAAEAAAAADW5sYWdyaWN1bHR1cmUCbmwAAAEAAcAMADAAAQAAAAAABAEBAwg=");
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat( $data );
+    my ( $rr, @extra ) = $p->answer;
+    eq_or_diff \@extra, [], "no extra RRs found";
+    if ( !defined $rr ) {
+        BAIL_OUT( "no RR found" );
+    }
+    is $rr->keydata, "", "we're able to extract the public key field even when it's empty";
 };
 
 subtest 'RRSIG' => sub {


### PR DESCRIPTION
## Purpose

This PR makes us ignore DNSKEY RRs with empty public key fields instead of crashing.

## Context

Fixes #110.
Implements the specification updates from zonemaster/zonemaster#1041.

## Changes

* Zonemaster::LDNS::RR::DNSKEY::keydata() is updated to work with ldns's internal representation of an empty DNSKEY public key field. (An issue has been created about changing the internal interpretation: nlnetlabs/ldns#156)
* Zonemaster::LDNS::RR::keysize() is ported from XS to Perl.
* Zonemaster::LDNS::RR::keysize() is fixed to return the `-1` sentinel value instead of crashing or returning a negative number of bits.
* Zonemaster::LDNS::Package::answer() is changed to filter out DNSKEY RRs with incalculable key sizes. The old behavior is still available under a new name: Zonemaster::LDNS::Package::answer_unfiltered().

## How to test this PR

A test case is provided in #110.

### Notes

After this PR when a zone with a single bad DNSKEY whose key size is incalculable, we get the following behaviors:
* DNSSEC03 emits a NO_DNSKEY message.
* DNSSEC07 emits a DS_BUT_NOT_DNSKEY message.
* DNSSEC05 emits one NO_RESPONSE_DNSKEY message for each name server that returned the bad DNSKEY record.
* DNSSEC14 emits one NO_RESPONSE_DNSKEY message for each name server that returned the bad DNSKEY record.

In principle I believe these are reasonable behaviors, but at least some of the tag names are a bit misleading. Especially the word "response" is unfortunate in this context. Perhaps it would also make sense to qualify "dnskey" with the adjective "valid" since there might actually be an RR in the answer section with the DNSKEY type that just happens to be broken enough that it is ignored.