### PR TITLE
Use Net::LibIDN2

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -100,7 +100,6 @@ if ( $opt_idn ) {
     print "Feature idn enabled\n";
     eval( "use Net::LibIDN2" );
     die "Missing Net::LibIDN2 module. Aborting.\n" if ( $@ );
-    cc_define '-DWE_CAN_HAZ_IDN';
 }
 else {
     print "Feature idn disabled\n";

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -98,13 +98,8 @@ else {
 
 if ( $opt_idn ) {
     print "Feature idn enabled\n";
-    check_lib_or_exit(
-        lib    => 'idn',
-        header => 'idna.h',
-        function =>
-          'if(strcmp(IDNA_ACE_PREFIX,"xn--")==0) return 0; else return 1;'
-    );
-    cc_libs 'idn';
+    eval( "use Net::LibIDN2" );
+    die "Missing Net::LibIDN2 module. Aborting.\n" if ( $@ );
     cc_define '-DWE_CAN_HAZ_IDN';
 }
 else {

--- a/include/LDNS.h
+++ b/include/LDNS.h
@@ -12,10 +12,6 @@
 #include <ctype.h>
 #include <ldns/ldns.h>
 
-#ifdef WE_CAN_HAZ_IDN
-#include <idna.h>
-#endif
-
 /* ldns 1.6.17 does not have this in its header files, but it is in the published documentation and we need it */
 /* It looks like 1.6.18 will have it, but we'll fix that when it happens. */
 #if (LDNS_REVISION) >= ((1<<16)|(6<<8)|(17))

--- a/lib/Zonemaster/LDNS.pm
+++ b/lib/Zonemaster/LDNS.pm
@@ -13,7 +13,7 @@ XSLoader::load( __PACKAGE__, $VERSION );
 
 use Zonemaster::LDNS::RR;
 use Zonemaster::LDNS::Packet;
-use Zonemaster::LDNS::IDN;
+use Zonemaster::LDNS::IDN qw(has_idn to_idn);
 
 1;
 

--- a/lib/Zonemaster/LDNS.pm
+++ b/lib/Zonemaster/LDNS.pm
@@ -13,6 +13,7 @@ XSLoader::load( __PACKAGE__, $VERSION );
 
 use Zonemaster::LDNS::RR;
 use Zonemaster::LDNS::Packet;
+use Zonemaster::LDNS::IDN;
 
 1;
 

--- a/lib/Zonemaster/LDNS/IDN.pm
+++ b/lib/Zonemaster/LDNS/IDN.pm
@@ -1,0 +1,39 @@
+package Zonemaster::LDNS::IDN;
+
+use strict;
+use warnings;
+
+use Carp;
+
+my $idn_available = 0;
+
+eval {
+    use Net::LibIDN2 ':all';
+};
+
+if ( ! $@ ) {
+    $idn_available = 1;
+}
+
+sub has_idn {
+    return $idn_available;
+}
+
+sub to_idn {
+    if ( !has_idn ) {
+        croak( "Module Net::LibIDN2 not installed." );
+    }
+
+    my @dst;
+    for ( $@ ) {
+        my $rc;
+        my $out = Net::LibIDN2::idn2_to_ascii_8( $_, undef, $rc );
+        if ( $rc == IDN2_OK ) {
+            push @dst, $out;
+        }
+        else {
+          croak( "Error: %s\n", Net::LibIDN2::idn2_strerror( $rc ) );
+        }
+    }
+    return @dst;
+}

--- a/lib/Zonemaster/LDNS/IDN.pm
+++ b/lib/Zonemaster/LDNS/IDN.pm
@@ -38,5 +38,10 @@ sub to_idn {
           croak( "Error: %s\n", Net::LibIDN2::idn2_strerror( $rc ) );
         }
     }
-    return @dst;
+
+    if ( scalar @dst > 1 ) {
+        return @dst;
+    } else {
+        return $dst[0];
+    }
 }

--- a/lib/Zonemaster/LDNS/IDN.pm
+++ b/lib/Zonemaster/LDNS/IDN.pm
@@ -5,6 +5,9 @@ use warnings;
 
 use Carp;
 
+use parent 'Exporter';
+our @EXPORT_OK = qw[has_idn to_idn];
+
 my $idn_available = 0;
 
 eval {
@@ -20,14 +23,14 @@ sub has_idn {
 }
 
 sub to_idn {
-    if ( !has_idn ) {
+    if ( !has_idn() ) {
         croak( "Module Net::LibIDN2 not installed." );
     }
 
     my @dst;
-    for ( $@ ) {
-        my $rc;
-        my $out = Net::LibIDN2::idn2_to_ascii_8( $_, undef, $rc );
+    for ( @_ ) {
+        my $rc = -1;
+        my $out = Net::LibIDN2::idn2_to_ascii_8( $_, IDN2_NFC_INPUT, $rc );
         if ( $rc == IDN2_OK ) {
             push @dst, $out;
         }

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -4,50 +4,6 @@ MODULE = Zonemaster::LDNS        PACKAGE = Zonemaster::LDNS
 
 PROTOTYPES: ENABLE
 
-SV *
-to_idn(...)
-    PPCODE:
-    {
-#ifdef WE_CAN_HAZ_IDN
-        int i;
-        for( i = 0; i<items; i++ )
-        {
-            char *out;
-            int status;
-            SV *obj = ST(i);
-
-            if (SvPOK(ST(i)))
-            {
-               status = idna_to_ascii_8z(SvPVutf8_nolen(obj), &out, IDNA_ALLOW_UNASSIGNED);
-               if (status == IDNA_SUCCESS)
-               {
-                  SV *new = newSVpv(out,0);
-                  SvUTF8_on(new); /* We know the string is plain ASCII, so let Perl know too */
-                  mXPUSHs(new);
-                  free(out);
-               }
-               else
-               {
-                  croak("Error: %s\n", idna_strerror(status));
-               }
-            }
-        }
-#else
-        croak("libidn not installed");
-#endif
-    }
-
-bool
-has_idn()
-    CODE:
-#ifdef WE_CAN_HAZ_IDN
-        RETVAL = 1;
-#else
-        RETVAL = 0;
-#endif
-    OUTPUT:
-        RETVAL
-
 bool
 has_gost()
 	CODE:

--- a/t/idn.t
+++ b/t/idn.t
@@ -1,7 +1,5 @@
 use Test::More;
 use Test::Fatal;
-use Encode;
-use Devel::Peek;
 use utf8;
 
 BEGIN { use_ok( "Zonemaster::LDNS" => qw[:all] ) }

--- a/t/idn.t
+++ b/t/idn.t
@@ -7,7 +7,7 @@ use utf8;
 BEGIN { use_ok( "Zonemaster::LDNS" => qw[:all] ) }
 
 no warnings 'uninitialized';
-if (exception {to_idn("whatever")} =~ /libidn not installed/) {
+if (exception {to_idn("whatever")} =~ /Module Net::LibIDN2 not installed/) {
     ok(!has_idn(), 'No IDN');
     done_testing;
     exit;


### PR DESCRIPTION
## Purpose

Use https://metacpan.org/pod/Net::LibIDN2 instead of XS code around libidn2.

## Context

Addresses #131 and follow a suggestion from #133

## Changes

...

## How to test this PR

...

## Todo

- [ ] replace all ref to libidn with the Net::LibIDN2 module
- [ ] choose which flags to pass to `Net::LibIDN2::idn2_to_ascii_8()`
- [ ] remove `--idn` option