### PR TITLE
Libidn2 backward compatible with IDNA2003

### DIFF
--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -19,17 +19,13 @@ to_idn(...)
             if (SvPOK(ST(i)))
             {
                status = idn2_to_ascii_8z(SvPVutf8_nolen(obj), &out, IDN2_ALLOW_UNASSIGNED);
-               if (status == IDN2_OK)
-               {
-                  SV *new = newSVpv(out,0);
-                  SvUTF8_on(new); /* We know the string is plain ASCII, so let Perl know too */
-                  mXPUSHs(new);
-                  free(out);
-               }
-               else
-               {
+               if (status != IDN2_OK)
                   croak("Error: %s\n", idn2_strerror(status));
-               }
+
+               SV *new = newSVpv(out,0);
+               SvUTF8_on(new); /* We know the string is plain ASCII, so let Perl know too */
+               mXPUSHs(new);
+               free(out);
             }
         }
 #else

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -18,7 +18,11 @@ to_idn(...)
 
             if (SvPOK(ST(i)))
             {
-               status = idn2_to_ascii_8z(SvPVutf8_nolen(obj), &out, IDN2_ALLOW_UNASSIGNED);
+               status = idn2_to_ascii_8z(SvPVutf8_nolen(obj), &out, IDN2_NONTRANSITIONAL);
+
+               if (status == IDN2_DISALLOWED)
+                  status = idn2_to_ascii_8z(SvPVutf8_nolen(obj), &out, IDN2_TRANSITIONAL);
+
                if (status != IDN2_OK)
                   croak("Error: %s\n", idn2_strerror(status));
 

--- a/t/idn.t
+++ b/t/idn.t
@@ -27,4 +27,11 @@ is_deeply(
 
 like( exception { to_idn( "ö" x 63 ) }, qr/Punycode/i, 'Boom today' );
 
+subtest 'test domain with symbol (backward compatibility)' => sub {
+    my $domain = "👍.example";
+    $encoded = to_idn( $domain );
+    my $expected = "xn--yp8h.example";
+    is( $encoded, $expected, 'IDNA2003 supported' );
+};
+
 done_testing;


### PR DESCRIPTION
## Purpose

With the libidn2 migration and the IDNA2008 mappings, Zonemaster can't test a domain with a symbol if it is not given in its encoded form (try for instance with `👍.example` and [`xn--yp8h.example`](https://zonemaster.net/result/0a5a863321f83d96)).

Even though ICANN [agreed that it is ok to prevent symbol mappings in IDNA2008](https://features.icann.org/ssac-advisory-use-emoji-domain-names), [emoji domains](https://en.wikipedia.org/wiki/Emoji_domain) exist (see for instance [https://i❤️.ws/](https://xn--i-7iq.ws/)). Therefore it would be nice if Zonemaster could automatically encode the domain and test it.

## Context

n/a

## Changes

Following [recommendations in libidn2 manual](https://libidn.gitlab.io/libidn2/manual/libidn2.html#Converting-with-backwards-compatibility), the `to_idn()` method is updated to be IDNA2003 compatible.

## How to test this PR

A unit test is added. This PR can also be manually tested, `perl -MZonemaster::LDNS -MEncode -e 'Zonemaster::LDNS::to_idn( decode_utf8( "👍.tld" ) )'` sould not give any error.


credits to @blacksponge for spotting this