### PR TITLE
Add support for NSID option + update internal LDNS to 1.8.3 

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -11,6 +11,8 @@ inc/Module/Install/Win32.pm
 inc/Module/Install/WriteAll.pm
 inc/Module/Install/XSUtil.pm
 include/LDNS.h
+ldns/.github/FUNDING.yml
+ldns/.github/workflows/testsuite.yml
 ldns/buffer.c
 ldns/compat/b64_ntop.c
 ldns/compat/b64_pton.c
@@ -66,6 +68,7 @@ ldns/ldns/update.h
 ldns/ldns/util.h.in
 ldns/ldns/wire2host.h
 ldns/ldns/zone.h
+ldns/libdns.doxygen.in
 ldns/LICENSE
 ldns/ltmain.sh
 ldns/Makefile.in
@@ -77,6 +80,7 @@ ldns/parse.c
 ldns/radix.c
 ldns/rbtree.c
 ldns/rdata.c
+ldns/README-Travis.md
 ldns/resolver.c
 ldns/rr.c
 ldns/rr_functions.c

--- a/MANIFEST
+++ b/MANIFEST
@@ -25,6 +25,7 @@ ldns/dnssec_sign.c
 ldns/dnssec_verify.c
 ldns/dnssec_zone.c
 ldns/duration.c
+ldns/edns.c
 ldns/error.c
 ldns/higher.c
 ldns/host2str.c
@@ -41,6 +42,7 @@ ldns/ldns/dnssec_sign.h
 ldns/ldns/dnssec_verify.h
 ldns/ldns/dnssec_zone.h
 ldns/ldns/duration.h
+ldns/ldns/edns.h
 ldns/ldns/error.h
 ldns/ldns/higher.h
 ldns/ldns/host2str.h

--- a/MANIFEST
+++ b/MANIFEST
@@ -182,6 +182,7 @@ t/example.org
 t/idn.t
 t/load_zonefile.t
 t/netldns.t
+t/nsid.t
 t/packet.t
 t/regression.t
 t/resolver.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -213,12 +213,15 @@ else {
 }
 
 
-# LDNS
+# LDNS and NSID
+
+my $ldns_has_nsid;
 
 if ( $opt_internal_ldns ) {
     print "Feature internal ldns enabled\n";
     cc_libs '-Lldns/lib';
     cc_include_paths 'ldns';
+    $ldns_has_nsid = 1;
 }
 else {
     print "Feature internal ldns disabled\n";
@@ -241,16 +244,16 @@ else {
             function => 'if(LDNS_ED25519) return 0; else return 1;'
         );
     }
-}
 
-# NSID feature requires LDNS version >= 1.8.2
-my $ldns_has_nsid = check_lib(
-    debug    => $opt_debug,
-    lib      => 'ldns',
-    header   => 'ldns/util.h',
-    %{ $assert_lib_args{ldns} },
-    function => 'if ( LDNS_REVISION >= ((1<<16)|(8<<8)|(2)) ) return 0; else return 1;'
-);
+    # NSID feature requires LDNS version >= 1.8.2
+    $ldns_has_nsid = check_lib(
+        debug    => $opt_debug,
+        lib      => 'ldns',
+        header   => 'ldns/util.h',
+        %{ $assert_lib_args{ldns} },
+        function => 'if ( LDNS_REVISION >= ((1<<16)|(8<<8)|(2)) ) return 0; else return 1;'
+    );
+}
 
 if ( $ldns_has_nsid ) {
     print "Feature NSID enabled\n";

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -243,6 +243,23 @@ else {
     }
 }
 
+# NSID feature requires LDNS version >= 1.8.2
+my $ldns_has_nsid = check_lib(
+    debug    => $opt_debug,
+    lib      => 'ldns',
+    header   => 'ldns/util.h',
+    %{ $assert_lib_args{ldns} },
+    function => 'if ( LDNS_REVISION >= ((1<<16)|(8<<8)|(2)) ) return 0; else return 1;'
+);
+
+if ( $ldns_has_nsid ) {
+    print "Feature NSID enabled\n";
+    cc_define '-DNSID_SUPPORT';
+}
+else {
+    print "Feature NSID disabled\n";
+}
+
 
 # Libidn
 

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1407,6 +1407,60 @@ packet_needs_edns(obj)
     OUTPUT:
         RETVAL
 
+#
+# Function: nsid
+# --------------
+# Set the EDNS option NSID in the packet
+#
+void
+packet_nsid(obj)
+    Zonemaster::LDNS::Packet obj;
+    CODE:
+        ldns_edns_option_list* edns_list;
+        ldns_edns_option*      edns_opt;
+
+        edns_list = ldns_edns_option_list_new();
+        edns_opt  = ldns_edns_new_from_data(LDNS_EDNS_NSID, 0, NULL);
+        if ( edns_list == NULL || edns_opt == NULL )
+            croak("Could not allocate EDNS option");
+        if ( ! ldns_edns_option_list_push(edns_list, edns_opt) )
+            croak("Could not attach EDNS option NSID");
+        ldns_pkt_set_edns_option_list(obj, edns_list);
+
+#
+# Function: get_nsid
+# ------------------
+# Get the EDNS option NSID if any from the packet
+#
+# returns: a bytes string (or undef if no NSID is found)
+#
+SV *
+packet_get_nsid(obj)
+    Zonemaster::LDNS::Packet obj;
+    CODE:
+        ldns_edns_option_list* edns_list;
+        ldns_edns_option* edns_opt;
+        size_t count;
+
+        edns_list = ldns_pkt_edns_get_option_list(obj);
+        if ( edns_list == NULL )
+            XSRETURN_UNDEF;
+
+        RETVAL = NULL;
+        count = ldns_edns_option_list_get_count(edns_list);
+        for ( int i=0; i<count; i++ )
+        {
+            edns_opt = ldns_edns_option_list_get_option(edns_list, i);
+            if ( edns_opt == NULL )
+                continue;
+            if ( ldns_edns_get_code(edns_opt) == LDNS_EDNS_NSID )
+                RETVAL = newSVpv(ldns_edns_get_data(edns_opt), ldns_edns_get_size(edns_opt));
+        }
+        if ( RETVAL == NULL )
+            XSRETURN_UNDEF;
+    OUTPUT:
+        RETVAL
+
 SV *
 packet_type(obj)
     Zonemaster::LDNS::Packet obj;

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1416,6 +1416,8 @@ void
 packet_nsid(obj)
     Zonemaster::LDNS::Packet obj;
     CODE:
+    {
+#ifdef NSID_SUPPORT
         ldns_edns_option_list* edns_list;
         ldns_edns_option*      edns_opt;
 
@@ -1426,6 +1428,10 @@ packet_nsid(obj)
         if ( ! ldns_edns_option_list_push(edns_list, edns_opt) )
             croak("Could not attach EDNS option NSID");
         ldns_pkt_set_edns_option_list(obj, edns_list);
+#else
+        croak("NSID not supported");
+#endif
+    }
 
 #
 # Function: get_nsid
@@ -1438,6 +1444,8 @@ SV *
 packet_get_nsid(obj)
     Zonemaster::LDNS::Packet obj;
     CODE:
+    {
+#ifdef NSID_SUPPORT
         ldns_edns_option_list* edns_list;
         ldns_edns_option* edns_opt;
         size_t count;
@@ -1458,6 +1466,10 @@ packet_get_nsid(obj)
         }
         if ( RETVAL == NULL )
             XSRETURN_UNDEF;
+#else
+        croak("NSID not supported");
+#endif
+    }
     OUTPUT:
         RETVAL
 

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1421,7 +1421,11 @@ packet_nsid(obj)
         ldns_edns_option_list* edns_list;
         ldns_edns_option*      edns_opt;
 
-        edns_list = ldns_edns_option_list_new();
+        edns_list = ldns_pkt_edns_get_option_list(obj);
+
+        if ( !edns_list )
+            edns_list = ldns_edns_option_list_new();
+
         edns_opt  = ldns_edns_new_from_data(LDNS_EDNS_NSID, 0, NULL);
         if ( edns_list == NULL || edns_opt == NULL )
             croak("Could not allocate EDNS option");

--- a/t/nsid.t
+++ b/t/nsid.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Zonemaster::LDNS;
+
+SKIP: {
+    skip 'no network', 1 unless $ENV{TEST_WITH_NETWORK};
+
+    my $host = '192.134.4.1'; #ns1.nic.fr with nsid: ns1.th3.nic.fr
+    my $expected_nsid = "ns1.th3.nic.fr";
+
+    my $pkt = Zonemaster::LDNS::Packet->new('domain.example');
+    $pkt->nsid; # set the NSID EDNS option
+    my $res = Zonemaster::LDNS->new($host)->query_with_pkt($pkt);
+
+    my $nsid = $res->get_nsid();
+
+    is( $nsid, $expected_nsid, 'Correct NSID' );
+};
+
+done_testing();


### PR DESCRIPTION
## Purpose

Since version 1.8.2 ([released earlier this year](https://github.com/NLnetLabs/ldns/blob/1.8.2/Changelog)) LDNS can easily retrieve the NSID from the nameserver. This is a proof of concept to retrieve the NSID in Zonemaster::LDNS.

## Context

Addresses https://github.com/zonemaster/zonemaster-engine/issues/178#issuecomment-1174863303
Addresses #143.

## Changes

* New `nsid` and `get_nsid` methods for Zonemaster::LDNS::Packet.
* Update internal LDNS to 1.8.3.

## How to test this PR

After installing [ldns 1.8.2](https://nlnetlabs.nl/downloads/ldns/ldns-1.8.2.tar.gz) (or later), the following snippet should return the NSID from the host it connects to (if any):
```perl
use Zonemaster::LDNS;
#print(Zonemaster::LDNS::lib_version() . "\n");

my $host = '194.0.9.1';
my $pkt = Zonemaster::LDNS::Packet->new('domain.example');
$pkt->nsid; # set the NSID EDNS option
my $res = Zonemaster::LDNS->new($host)->query_with_pkt($pkt);
print($res->get_nsid() . "\n");
```
