### PR TITLE
Fix unsafe string manipulations in XS code

### DIFF
--- a/include/LDNS.h
+++ b/include/LDNS.h
@@ -108,6 +108,7 @@ typedef ldns_rr *Zonemaster__LDNS__RR__X25;
 
 SV *rr2sv(ldns_rr *rr);
 char *randomize_capitalization(char *in);
+void strip_newline(char* in);
 
 #ifdef USE_ITHREADS
 void net_ldns_remember_resolver(SV *rv);

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1233,7 +1233,14 @@ packet_string(obj)
     Zonemaster::LDNS::Packet obj;
     CODE:
         RETVAL = ldns_pkt2str(obj);
-        RETVAL[strlen(RETVAL)-1] = '\0';
+        if(RETVAL == NULL || RETVAL[0] == '\0')
+        {
+            croak("Failed to convert packet to string");
+        }
+        else
+        {
+            strip_newline(RETVAL);
+        }
     OUTPUT:
         RETVAL
     CLEANUP:
@@ -1597,7 +1604,14 @@ rr_string(obj)
     Zonemaster::LDNS::RR obj;
     CODE:
         RETVAL = ldns_rr2str(obj);
-        RETVAL[strlen(RETVAL)-1] = '\0';
+        if(RETVAL == NULL || RETVAL[0] == '\0')
+        {
+            croak("Failed to convert RR to string");
+        }
+        else
+        {
+            strip_newline(RETVAL);
+        }
     OUTPUT:
         RETVAL
     CLEANUP:

--- a/src/assist.c
+++ b/src/assist.c
@@ -228,3 +228,20 @@ rr2sv(ldns_rr *rr)
 
     return rr_sv;
 }
+
+void
+strip_newline(char* in)
+{
+    size_t length;
+
+    if (in == NULL || in[0] == '\0')
+    {
+        return;
+    }
+
+    length = strlen(in);
+    if (in[length - 1] == '\n')
+    {
+        in[length - 1] = '\0';
+    }
+}

--- a/t/rr.t
+++ b/t/rr.t
@@ -226,4 +226,12 @@ subtest 'SPF' => sub {
     is( $spf->spfdata, '"v=spf1 ip4:85.30.129.185/24 mx:mail.frobbit.se ip6:2a02:80:3ffe::0/64 ~all"' );
 };
 
+subtest 'croak when given malformed CAA records' => sub {
+    my $will_croak = sub {
+        Zonemaster::LDNS::RR->new(
+            'bad-caa.example.       3600    IN      CAA     \# 4 C0000202' )
+    };
+    like( exception { $will_croak->() }, qr/^Failed to convert RR to string/ );
+};
+
 done_testing;

--- a/t/rr.t
+++ b/t/rr.t
@@ -228,8 +228,11 @@ subtest 'SPF' => sub {
 
 subtest 'croak when given malformed CAA records' => sub {
     my $will_croak = sub {
-        Zonemaster::LDNS::RR->new(
-            'bad-caa.example.       3600    IN      CAA     \# 4 C0000202' )
+        # This will croak if LDNS.xs is compiled with -DUSE_ITHREADS
+        my $bad_caa = Zonemaster::LDNS::RR->new(
+            'bad-caa.example.       3600    IN      CAA     \# 4 C0000202' );
+        # This will always croak
+        $bad_caa->string();
     };
     like( exception { $will_croak->() }, qr/^Failed to convert RR to string/ );
 };


### PR DESCRIPTION
## Purpose

This PR addresses unsafe string handling in the XS code, called when using the `string()` method of Zonemaster::LDNS::Packet and Zonemaster::LDNS::RR.

## Context

Fixes #149.

## Changes

Add checks to the return values of `ldns_rr2str()` and `ldns_pkt2str()`. Ensure that the pointers to strings returned by these functions are not NULL and that the strings are not empty before operating on them.

## How to test this PR

Unit tests were added which reproduce the circumstances of the crashes I witnessed, so unit tests must pass.

You can also test this PR manually:

1. Download [corrupted-a.txt](https://github.com/zonemaster/zonemaster-ldns/files/9469654/corrupted-a.txt) (attached to #149).
2. Run `zonemaster-cli --restore corrupted-a.txt --ns ns.test/172.30.131.174 test` and expect no segmentation fault (be sure that it’s using a patched version of Zonemaster::LDNS).
3. Run the following one-liner:
```sh
perl -MZonemaster::LDNS -e 'Zonemaster::LDNS::RR->new("bad-caa.example. IN CAA \\# 4 C0000202")->string'
```
Expect an error message starting with “Failed to convert RR to string”.
