### PR TITLE
Make RR::CDS (resp RR::CDNSKEY) subclass of RR::DS (resp RR::DNSKEY) 

### DIFF
--- a/lib/Zonemaster/LDNS/RR/CDNSKEY.pm
+++ b/lib/Zonemaster/LDNS/RR/CDNSKEY.pm
@@ -3,7 +3,7 @@ package Zonemaster::LDNS::RR::CDNSKEY;
 use strict;
 use warnings;
 
-use parent 'Zonemaster::LDNS::RR';
+use parent 'Zonemaster::LDNS::RR::DNSKEY';
 
 1;
 
@@ -13,7 +13,7 @@ Zonemaster::LDNS::RR::CDNSKEY - Type CDNSKEY record
 
 =head1 DESCRIPTION
 
-A subclass of L<Zonemaster::LDNS::RR>, so it has all the methods of that class available in addition to the ones documented here.
+A subclass of L<Zonemaster::LDNS::RR::DNSKEY>, so it has all the methods of that class available in addition to the ones documented here.
 
 =head1 METHODS
 

--- a/lib/Zonemaster/LDNS/RR/CDS.pm
+++ b/lib/Zonemaster/LDNS/RR/CDS.pm
@@ -3,7 +3,7 @@ package Zonemaster::LDNS::RR::CDS;
 use strict;
 use warnings;
 
-use parent 'Zonemaster::LDNS::RR';
+use parent 'Zonemaster::LDNS::RR::DS';
 
 1;
 
@@ -13,7 +13,7 @@ Zonemaster::LDNS::RR::CDS - Type CDS record
 
 =head1 DESCRIPTION
 
-A subclass of L<Zonemaster::LDNS::RR>, so it has all the methods of that class available in addition to the ones documented here.
+A subclass of L<Zonemaster::LDNS::RR::DS>, so it has all the methods of that class available in addition to the ones documented here.
 
 =head1 METHODS
 

--- a/lib/Zonemaster/LDNS/RR/DNSKEY.pm
+++ b/lib/Zonemaster/LDNS/RR/DNSKEY.pm
@@ -31,6 +31,10 @@ Returns the protocol number.
 
 Returns the algorithm number.
 
+=item keytag()
+
+Returns the keytag value.
+
 =item keydata()
 
 Returns the cryptographic key in binary form.

--- a/t/rr.t
+++ b/t/rr.t
@@ -226,4 +226,28 @@ subtest 'SPF' => sub {
     is( $spf->spfdata, '"v=spf1 ip4:85.30.129.185/24 mx:mail.frobbit.se ip6:2a02:80:3ffe::0/64 ~all"' );
 };
 
+subtest 'CDS' => sub {
+    my $data = "cds.example. 0 IN CDS 51298 13 2 60A48DB6C1F4B993E3D7C0869C0C535A70C9A6D1899DE86563D485B5 15EE1918";
+
+    my $rr = Zonemaster::LDNS::RR->new($data);
+
+    isa_ok( $rr, 'Zonemaster::LDNS::RR::CDS' );
+    is( $rr->keytag,    51298 );
+    is( $rr->algorithm, 13 );
+    is( $rr->digtype, 2 );
+    is( $rr->hexdigest, '60a48db6c1f4b993e3d7c0869c0c535a70c9a6d1899de86563d485b515ee1918' );
+};
+
+subtest 'CDNSKEY' => sub {
+    my $data = "cdnskey.example. 0 IN CDNSKEY 257 3 13 6/8fEc37k5iabGoWgsl7rmreQth8ADr9sYFGd0pxmgxN19MBR629YAH5 ntzSus7SjJx6PAVqGzHHpCPVyDLQHQ==";
+
+    my $rr = Zonemaster::LDNS::RR->new($data);
+
+    isa_ok( $rr, 'Zonemaster::LDNS::RR::CDNSKEY' );
+    is( $rr->flags, 257 );
+    is( $rr->protocol,  3 );
+    is( $rr->algorithm, 13 );
+    is( $rr->keytag,    51298 );
+};
+
 done_testing;


### PR DESCRIPTION
## Purpose

Instead of implementing specific methods, reuse the one from Zonemaster::LDNS::RR::DS and Zonemaster::LDNS::RR::DNSKEY since a CDS (resp CDNSKEY) record is identical to a DS (DNSKEY) record, see [RFC 7344 section 3.1 and 3.2](https://www.rfc-editor.org/rfc/rfc7344#section-3.1).

## Context

#114

## Changes

* make Zonemaster::LDNS::RR::CDS a subclass of Zonemaster::LDNS::RR::DS
* make Zonemaster::LDNS::RR::CDNSKEY a subclass of Zonemaster::LDNS::RR::DNSKEY

## How to test this PR

Unit tests are provided.
