### PR TITLE
Improve access to text data in TXT and SPF resource records

### DIFF
--- a/lib/Zonemaster/LDNS/RR/SPF.pm
+++ b/lib/Zonemaster/LDNS/RR/SPF.pm
@@ -5,6 +5,12 @@ use warnings;
 
 use parent 'Zonemaster::LDNS::RR';
 
+sub spfdata() {
+    my ($rr) = @_;
+
+    return join( "", map { substr($rr->rdf($_ - 1), 1) } 1..$rr->rd_count() );
+}
+
 1;
 
 =head1 NAME
@@ -21,6 +27,12 @@ A subclass of L<Zonemaster::LDNS::RR>, so it has all the methods of that class a
 
 =item spfdata()
 
-Returns the SPF string.
+Returns the concatenation of all the strings composing the data of the resource record.
+
+For example, if an SPF resource record has the following presentation format:
+
+    test.example. 3600 IN SPF "v=spf1 " "mx " "a " "-all"
+
+then C<spfdata()> returns the string C<"v=spf1 mx a -all">.
 
 =back

--- a/lib/Zonemaster/LDNS/RR/TXT.pm
+++ b/lib/Zonemaster/LDNS/RR/TXT.pm
@@ -5,6 +5,12 @@ use warnings;
 
 use parent 'Zonemaster::LDNS::RR';
 
+sub txtdata() {
+    my ($rr) = @_;
+
+    return join( "", map { substr($rr->rdf($_ - 1), 1) } 1..$rr->rd_count() );
+}
+
 1;
 
 =head1 NAME
@@ -21,6 +27,12 @@ A subclass of L<Zonemaster::LDNS::RR>, so it has all the methods of that class a
 
 =item txtdata()
 
-Returns the text data.
+Returns the concatenation of all the strings composing the data of the resource record.
+
+For example, if a TXT resource record has the following presentation format:
+
+    txt.test.example. 3600 IN TXT "I " "am " "split up in " "lit" "tle pieces"
+
+then C<txtdata()> returns the string C<"I am split up in little pieces">.
 
 =back

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -2366,19 +2366,6 @@ rr_cname_cname(obj)
     CLEANUP:
         free(RETVAL);
 
-
-MODULE = Zonemaster::LDNS        PACKAGE = Zonemaster::LDNS::RR::TXT              PREFIX=rr_txt_
-
-char *
-rr_txt_txtdata(obj)
-    Zonemaster::LDNS::RR::TXT obj;
-    CODE:
-        RETVAL = D_STRING(obj,0);
-    OUTPUT:
-        RETVAL
-    CLEANUP:
-        free(RETVAL);
-
 MODULE = Zonemaster::LDNS        PACKAGE = Zonemaster::LDNS::RR::SPF              PREFIX=rr_spf_
 
 char *

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -2366,18 +2366,6 @@ rr_cname_cname(obj)
     CLEANUP:
         free(RETVAL);
 
-MODULE = Zonemaster::LDNS        PACKAGE = Zonemaster::LDNS::RR::SPF              PREFIX=rr_spf_
-
-char *
-rr_spf_spfdata(obj)
-    Zonemaster::LDNS::RR::SPF obj;
-    CODE:
-        RETVAL = D_STRING(obj,0);
-    OUTPUT:
-        RETVAL
-    CLEANUP:
-        free(RETVAL);
-
 MODULE = Zonemaster::LDNS        PACKAGE = Zonemaster::LDNS::RR::KEY           PREFIX=rr_key_
 
 U16

--- a/t/rr.t
+++ b/t/rr.t
@@ -220,10 +220,19 @@ subtest 'SRV' => sub {
 };
 
 subtest 'SPF' => sub {
-    my $spf = Zonemaster::LDNS::RR->new(
-        'frobbit.se.		1127	IN	SPF	"v=spf1 ip4:85.30.129.185/24 mx:mail.frobbit.se ip6:2a02:80:3ffe::0/64 ~all"' );
-    isa_ok( $spf, 'Zonemaster::LDNS::RR::SPF' );
-    is( $spf->spfdata, '"v=spf1 ip4:85.30.129.185/24 mx:mail.frobbit.se ip6:2a02:80:3ffe::0/64 ~all"' );
+    my @data = (
+        q{frobbit.se.           1127    IN      SPF     "v=spf1 ip4:85.30.129.185/24 mx:mail.frobbit.se ip6:2a02:80:3ffe::0/64 ~all"},
+        q{spf.example.          3600    IN      SPF     "v=spf1 " "ip4:192.0.2.25/24 " "mx:mail.spf.example " "ip6:2001:db8::25/64 -all"}
+    );
+
+    my @rr = map { Zonemaster::LDNS::RR->new($_) } @data;
+    for my $spf (@rr) {
+        isa_ok( $spf, 'Zonemaster::LDNS::RR::SPF' );
+    }
+
+    is( $rr[0]->spfdata(), 'v=spf1 ip4:85.30.129.185/24 mx:mail.frobbit.se ip6:2a02:80:3ffe::0/64 ~all' );
+    is( $rr[1]->spfdata(), 'v=spf1 ip4:192.0.2.25/24 mx:mail.spf.example ip6:2001:db8::25/64 -all' );
+
 };
 
 done_testing;

--- a/t/rr.t
+++ b/t/rr.t
@@ -77,18 +77,18 @@ subtest 'AAAA' => sub {
 };
 
 subtest 'TXT' => sub {
-    SKIP: {
-        skip 'no network', 1 unless $ENV{TEST_WITH_NETWORK};
+    my @data = (
+        q{txt.test. 3600 IN TXT "Handling TXT RRs can be challenging"},
+        q{txt.test. 3600 IN TXT "because " "the data can " "be spl" "it up like " "this!"}
+    );
+    my @rrs = map { Zonemaster::LDNS::RR->new($_) } @data;
 
-        my $se = Zonemaster::LDNS->new( '192.36.144.107' );
-        my $pt = $se->query( 'se', 'TXT' );
-        plan skip_all => 'No response, cannot test' if not $pt;
-
-        foreach my $rr ( $pt->answer ) {
-            isa_ok( $rr, 'Zonemaster::LDNS::RR::TXT' );
-            like( $rr->txtdata, qr/^"SE zone update: / );
-        }
+    foreach my $rr ( @rrs ) {
+        isa_ok( $rr, 'Zonemaster::LDNS::RR::TXT' );
     }
+
+    is( $rrs[0]->txtdata(), q{Handling TXT RRs can be challenging} );
+    is( $rrs[1]->txtdata(), q{because the data can be split up like this!} );
 };
 
 subtest 'DNSKEY' => sub {


### PR DESCRIPTION
## Purpose

This PR introduces methods for better access to the data in TXT and SPF resource records.

## Context

Fixes #155.

Also related to https://github.com/zonemaster/zonemaster/pull/1100.

## Changes

In short:

- In Zonemaster::LDNS::RR::TXT, add the `text()` method (a `txtdata()` method already exists, but its behavior was rather surprising to me), returning either the list of strings in a TXT resource record in list context or its concatenation in scalar context;
- In Zonemaster::LDNS::RR::SPF, add the `spf()` method (a `spfdata()` method already exists with the same flaw as `txtdata()` for TXT records), returning the concatenated strings of the SPF resource record as one string (i.e. like the `text()` method for TXT resource records in scalar context).

Unit tests have been added along with the new code.

## How to test this PR

Unit tests shall pass.
