### PR TITLE
Automatically reconfigure internal libldns on "ldns/Changelog" updates

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -12,6 +12,7 @@ inc/Module/Install/WriteAll.pm
 inc/Module/Install/XSUtil.pm
 include/LDNS.h
 ldns/buffer.c
+ldns/Changelog
 ldns/compat/b64_ntop.c
 ldns/compat/b64_pton.c
 ldns/compat/strlcpy.c

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -16,7 +16,6 @@
 \.ac$
 
 # Avoid ldns files we don't need
-^ldns/Changelog$
 ^ldns/README$
 ^ldns/README\.
 ^ldns/\.libs/

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -352,12 +352,14 @@ ldns/.libs/libldns.a: ldns/configure
 	./configure CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" $(CONFIGURE_FLAGS) ;\
 	make lib
 
-ldns/configure:
+ldns/configure: ldns/Changelog
+	cd ldns ; libtoolize -ci
+	cd ldns ; autoreconf -fi
+
+ldns/Changelog:
 	git submodule init
 	git submodule sync
 	git submodule update
-	cd ldns ; libtoolize -ci
-	cd ldns ; autoreconf -fi
 
 END_INTERNAL_LDNS
 


### PR DESCRIPTION
## Purpose

* Fix an issue when checking out between different versions of libldns.
* Keep the `ldns/Changelog` file

## Context

Addresses remarks from #151 

## Changes

* Makefile.PL (use `ldns/Changelog` file as a prerequisite, if it's updated while checking out, then the module is rebuild)
* MANIFEST{,.SKIP} to keep `ldns/Changelog` in distribution file

## How to test this PR

1. use this PR branch
3. build Zonemaster-LDNS: `perl Makefile.PL && make`
4. check that libldns version is 1.7.1: `head ldns/configure` and `perl -I lib/ -I blib/arch/ -MZonemaster::LDNS -E 'say Zonemaster::LDNS::lib_version()'`
5. checkout to version 1.8.3 of libldns: `git -C ldns checkout 1.8.3` (verify with `git -C ldns log --oneline -1`)
6. rebuild Zonemaster-LDNS: `perl Makefile.PL && make`
7. check that libldns version is 1.8.3: `head ldns/configure` and `perl -I lib/ -I blib/arch/ -MZonemaster::LDNS -E 'say Zonemaster::LDNS::lib_version()'`