### PR TITLE
Corrects the license statement in LDNS.pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   * [Custom LDNS]
   * [Custom Libidn]
   * [Debug]
-
+* [License](#license)
 
 ## Introduction
 
@@ -223,6 +223,11 @@ Disabled by default.
 Enabled with `--debug`.
 
 Gives a more verbose output.
+
+## License
+
+This is free software under a 2-clause BSD license. The full text of the license can
+be found in the [LICENSE](LICENSE) file included in this respository.
 
 
 [Custom LDNS]:                                       #custom-ldns

--- a/lib/Zonemaster/LDNS.pm
+++ b/lib/Zonemaster/LDNS.pm
@@ -212,11 +212,7 @@ Calle Dybedahl <calle@init.se>
 
 =head1 LICENSE
 
-This is free software, licensed under:
-
-The (three-clause) BSD License
-
-The full text of the license can be found in the
-F<LICENSE> file included with this distribution.
+This is free software. The full text of the license can
+be found in the F<LICENSE> file included with this distribution.
 
 =cut

--- a/lib/Zonemaster/LDNS.pm
+++ b/lib/Zonemaster/LDNS.pm
@@ -212,7 +212,7 @@ Calle Dybedahl <calle@init.se>
 
 =head1 LICENSE
 
-This is free software. The full text of the license can
+This is free software under a 2-clause BSD license. The full text of the license can
 be found in the F<LICENSE> file included with this distribution.
 
 =cut


### PR DESCRIPTION
## Purpose

The statement about license in LDNS.pm is not correct, as pointed out by @emollier in https://github.com/zonemaster/zonemaster-engine/issues/1149

This PR updates the statement. It also adds the same message to README.

## How to test this PR

This is documentation change only.
