### PR TITLE
Fix build

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -343,7 +343,7 @@ END_OPENSSL_MAKE
 
     my $openssl_flags = <<END_OPENSSL_FLAGS;
 
-CFLAGS += -I$$opt_assets{penssl}{inc}
+CFLAGS += -I$$opt_assets{openssl}{inc}
 LDFLAGS += -L$$opt_assets{openssl}{lib}
 
 END_OPENSSL_FLAGS

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1459,7 +1459,7 @@ packet_get_nsid(obj)
 #ifdef NSID_SUPPORT
         ldns_edns_option_list* edns_list;
         ldns_edns_option* edns_opt;
-        size_t count;
+        size_t i,count;
 
         edns_list = ldns_pkt_edns_get_option_list(obj);
         if ( edns_list == NULL )
@@ -1467,7 +1467,7 @@ packet_get_nsid(obj)
 
         RETVAL = NULL;
         count = ldns_edns_option_list_get_count(edns_list);
-        for ( int i=0; i<count; i++ )
+        for ( i=0; i<count; i++ )
         {
             edns_opt = ldns_edns_option_list_get_option(edns_list, i);
             if ( edns_opt == NULL )


### PR DESCRIPTION
## Purpose

Fix a bug when building LDNS with link to OpenSSL.

## Context

This was encoutered while building Zonemaster-LDNS on CentOS 7.

## Changes

Makefile.PL and LDNS.xs

## How to test this PR

Build should work.
