### PR TITLE
use internal LDNS for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM alpine:3.14 as build
 RUN apk add --no-cache \
     # Compile-time dependencies
     build-base \
-    ldns-dev \
     libidn2-dev \
     make \
     openssl-dev \
@@ -20,7 +19,7 @@ ARG version
 
 COPY ./Zonemaster-LDNS-${version}.tar.gz ./Zonemaster-LDNS-${version}.tar.gz
 
-RUN cpanm --notest --no-wget --configure-args="--no-internal-ldns" \
+RUN cpanm --notest --no-wget \
     ./Zonemaster-LDNS-${version}.tar.gz
 
 FROM alpine:3.14
@@ -31,6 +30,5 @@ COPY --from=build /usr/local/lib/perl5/site_perl/Zonemaster /usr/local/lib/perl5
 
 RUN apk add --no-cache \
     # Run-time dependencies
-    ldns \
     libidn2 \
     perl


### PR DESCRIPTION
## Purpose

The docker image uses the system LDNS which is still in 1.7.1, we require 1.8.2 to use the new features.

## Context

\-

## Changes

Use the internal LDNS instead of the system one.

## How to test this PR

```
% make all dist docker-build
% docker run --rm zonemaster/ldns:local perl -MZonemaster::LDNS -e 'print(Zonemaster::LDNS::lib_version() . "\n");'
1.8.3
```