### PR TITLE
Update edns_data to return RDATA

### DIFF
--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1375,42 +1375,39 @@ packet_edns_version(obj,...)
 # -------------------
 # Get/set EDNS data
 # 
-# This function will set EDNS RDATA in a packet when given a parameter,
-# otherwise it will return the entire EDNS RDATA of the packet (if any).
+# This function will set OPT RDATA in a packet when given a parameter,
+# otherwise it will return the entire OPT RDATA of the packet (if any).
 #
-# Beware, when setting EDNS RDATA, this code can only take a unique U32 parameter
+# Beware, when setting OPT RDATA, this code can only take a unique U32 parameter
 # which means it is not a full implementation of EDNS data but it is enough for our
 # current purpose. It can only deal with option codes with OPTION-LENGTH=0
 # (see 6.1.2 section of RFC 6891) which means OPTION-DATA is always empty.
 #
-# returns: a bytes string (or undef if no EDNS data is found)
+# returns: a bytes string (or undef if no OPT RDATA is found)
 #
 SV *
 packet_edns_data(obj,...)
     Zonemaster::LDNS::Packet obj;
     CODE:
-        ldns_rdf* rdf;
+        ldns_rdf* opt;
         if(items>=2)
         {
             SvGETMAGIC(ST(1));
-            rdf = ldns_native2rdf_int32(LDNS_RDF_TYPE_INT32, (U32)SvIV(ST(1)));
-            if(rdf == NULL)
+            opt = ldns_native2rdf_int32(LDNS_RDF_TYPE_INT32, (U32)SvIV(ST(1)));
+            if(opt == NULL)
             {
-                croak("Failed to set rdf RDATA");
+                croak("Failed to set OPT RDATA");
             }
-            ldns_pkt_set_edns_data(obj, rdf);
-            RETVAL = newSVpvn((char*)(rdf), 4);
+            ldns_pkt_set_edns_data(obj, opt);
         }
         else {
-            rdf = ldns_pkt_edns_data(obj);
-            if(rdf == NULL)
+            opt = ldns_pkt_edns_data(obj);
+            if(opt == NULL)
             {
                 XSRETURN_UNDEF;
             }
-            else{
-                RETVAL = newSVpvn((char*)(rdf->_data), rdf->_size);
-            }
         }
+        RETVAL = newSVpvn((char*)(opt->_data), opt->_size);
     OUTPUT:
         RETVAL
 

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1375,8 +1375,10 @@ packet_edns_version(obj,...)
 # -------------------
 # Get/set EDNS data
 # 
-# This function will set OPT RDATA in a packet when given a parameter,
-# otherwise it will return the entire OPT RDATA of the packet (if any).
+# This function acts on the OPT RDATA field of a packet. An OPT RDATA consists of at least one triplet
+# {OPTION-CODE, OPTION-LENGTH, OPTION-DATA}.
+# When given a parameter, this function will set and return the field, although with the limitation described below.
+# Otherwise, it will get and return the field (if any).
 #
 # Beware, when setting OPT RDATA, this code can only take a unique U32 parameter
 # which means it is not a full implementation of EDNS data but it is enough for our

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1375,32 +1375,42 @@ packet_edns_version(obj,...)
 # -------------------
 # Get/set EDNS data
 # 
-# Beware, this code can only take a unique U32 parameter which means it 
-# is not a full implementation of EDNS data but it is enough for our 
+# This function will set EDNS RDATA in a packet when given a parameter,
+# otherwise it will return the entire EDNS RDATA of the packet (if any).
+#
+# Beware, when setting EDNS RDATA, this code can only take a unique U32 parameter
+# which means it is not a full implementation of EDNS data but it is enough for our
 # current purpose. It can only deal with option codes with OPTION-LENGTH=0
 # (see 6.1.2 section of RFC 6891) which means OPTION-DATA is always empty.
 #
-# returns: a bytes string
+# returns: a bytes string (or undef if no EDNS data is found)
 #
 SV *
 packet_edns_data(obj,...)
     Zonemaster::LDNS::Packet obj;
     CODE:
-        ldns_rdf* opt;
+        ldns_rdf* rdf;
         if(items>=2)
         {
             SvGETMAGIC(ST(1));
-            opt = ldns_native2rdf_int32(LDNS_RDF_TYPE_INT32, (U32)SvIV(ST(1)));
-            if(opt == NULL) 
+            rdf = ldns_native2rdf_int32(LDNS_RDF_TYPE_INT32, (U32)SvIV(ST(1)));
+            if(rdf == NULL)
             {
-                croak("Failed to set OPT RDATA");
+                croak("Failed to set rdf RDATA");
             }
-            ldns_pkt_set_edns_data(obj, opt);
+            ldns_pkt_set_edns_data(obj, rdf);
+            RETVAL = newSVpvn((char*)(rdf), 4);
         }
         else {
-            opt = ldns_pkt_edns_data(obj);
+            rdf = ldns_pkt_edns_data(obj);
+            if(rdf == NULL)
+            {
+                XSRETURN_UNDEF;
+            }
+            else{
+                RETVAL = newSVpvn((char*)(rdf->_data), rdf->_size);
+            }
         }
-        RETVAL = newSVpvn((char*)(opt), 4);
     OUTPUT:
         RETVAL
 


### PR DESCRIPTION
## Purpose

This PR proposes an update to the `edns_data` function in Zonemaster::LDNS to return the OPT RDATA of an EDNS packet instead of OPT RDLEN and LDNS RDF TYPE (see https://www.nlnetlabs.nl/documentation/ldns/structldns__struct__rdf.html).
This allows to check for all OPTION fields (OPTION-CODE, OPTION-LENGTH, OPTION-DATA) in an EDNS response packet.

## Context

Fixes https://github.com/zonemaster/zonemaster-engine/issues/1173

## Changes

- Setting or getting `edns_data` from a packet now returns OPT RDATA instead of OPT RDLEN and LDNS RDF TYPE
- Update documentation

## How to test this PR

Checkout this PR and:
```
perl Makefile.PL
make
```
Follow instructions in https://github.com/zonemaster/zonemaster-engine/pull/1177 from Zonemaster-Engine
