### PR TITLE
Validate inputs to Zonemaster::LDNS::RR::NSEC3::covers()

### DIFF
--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -2337,6 +2337,16 @@ bool
 rr_nsec3_covers(obj,name)
     Zonemaster::LDNS::RR::NSEC3 obj;
     const char *name;
+    INIT:
+        /* Sanity test on owner name */
+        if (ldns_dname_label_count(ldns_rr_owner(obj)) == 0)
+            XSRETURN_UNDEF;
+
+        /* Sanity test on hashed next owner field */
+        ldns_rdf *next_owner = ldns_nsec3_next_owner(obj);
+        if (!next_owner || ldns_rdf_size(next_owner) <= 1)
+            XSRETURN_UNDEF;
+
     CODE:
     {
         ldns_rr *clone;

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -2344,15 +2344,28 @@ rr_nsec3_covers(obj,name)
         ldns_rdf *hashed;
         ldns_rdf *chopped;
 
-        clone = ldns_rr_clone(obj);
         dname = ldns_rdf_new_frm_str(LDNS_RDF_TYPE_DNAME, name);
+        if (!dname)
+            XSRETURN_UNDEF;
+
         ldns_dname2canonical(dname);
+
+        chopped = ldns_dname_left_chop(dname);
+        if (!chopped) {
+            ldns_rdf_deep_free(dname);
+            XSRETURN_UNDEF;
+        }
+
+        clone = ldns_rr_clone(obj);
         ldns_rr2canonical(clone);
         hashed = ldns_nsec3_hash_name_frm_nsec3(clone, dname);
-        chopped = ldns_dname_left_chop(dname);
+
         ldns_rdf_deep_free(dname);
+
         ldns_dname_cat(hashed,chopped);
+
         RETVAL = ldns_nsec_covers_name(clone,hashed);
+
         ldns_rdf_deep_free(hashed);
         ldns_rdf_deep_free(chopped);
         ldns_rr_free(clone);

--- a/t/dnssec.t
+++ b/t/dnssec.t
@@ -59,9 +59,37 @@ my $nsec = Zonemaster::LDNS::RR->new('xx.se.			7200	IN	NSEC	xx0r.se. NS RRSIG NS
 isa_ok($nsec, 'Zonemaster::LDNS::RR::NSEC');
 ok($nsec->covers('xx-example.se'), 'Covers xx-example.se');
 
+ok(!$nsec->covers('.'), 'Does not cover the root domain');
+
 my $nsec3 = Zonemaster::LDNS::RR->new('NR2E513KM693MBTNVHH56ENF54F886T0.com. 86400 IN NSEC3 1 1 0 - NR2FUHQVR56LH70L6F971J3L6N1RH2TU NS DS RRSIG');
 isa_ok($nsec3, 'Zonemaster::LDNS::RR::NSEC3');
 ok($nsec3->covers('xx-example.com'), 'Covers xx-example.com');
+
+SKIP: {
+    skip 'guaranteed crash', 1;
+    is($nsec3->covers('.'), undef, 'Does not cover the root domain');
+}
+
+subtest 'malformed NSEC3 do not cover anything' => sub {
+    SKIP: {
+        skip 'guaranteed crash', 2;
+
+        # Malformed resource record lacking a next hashed owner name field in
+        # its RDATA. The only way to synthesize such a datum is to use the RFC
+        # 3597 syntax.
+        my $example = Zonemaster::LDNS::RR->new(
+            q{example. 0 IN NSEC3 \# 15 01 00 0001 01 AB 00 0006 400000000002}
+        );
+        is( $example->covers("example"), undef );
+
+        # NSEC3 resource record whose owner name is the root name. This should
+        # normally not happen.
+        $example = Zonemaster::LDNS::RR->new(
+            q{.        0 IN NSEC3 1 0 1 ab 01234567 A RRSIG}
+        );
+        is( $example->covers("example"), undef );
+    }
+};
 
 SKIP: {
     skip 'no network', 3 unless $ENV{TEST_WITH_NETWORK};

--- a/t/dnssec.t
+++ b/t/dnssec.t
@@ -68,24 +68,20 @@ ok($nsec3->covers('xx-example.com'), 'Covers xx-example.com');
 is($nsec3->covers('.'), undef, 'Does not cover the root domain');
 
 subtest 'malformed NSEC3 do not cover anything' => sub {
-    SKIP: {
-        skip 'guaranteed crash', 2;
+    # Malformed resource record lacking a next hashed owner name field in its
+    # RDATA. The only way to synthesize such a datum is to use the RFC 3597
+    # syntax.
+    my $example = Zonemaster::LDNS::RR->new(
+        q{example. 0 IN NSEC3 \# 15 01 00 0001 01 AB 00 0006 400000000002}
+    );
+    is( $example->covers("example"), undef );
 
-        # Malformed resource record lacking a next hashed owner name field in
-        # its RDATA. The only way to synthesize such a datum is to use the RFC
-        # 3597 syntax.
-        my $example = Zonemaster::LDNS::RR->new(
-            q{example. 0 IN NSEC3 \# 15 01 00 0001 01 AB 00 0006 400000000002}
-        );
-        is( $example->covers("example"), undef );
-
-        # NSEC3 resource record whose owner name is the root name. This should
-        # normally not happen.
-        $example = Zonemaster::LDNS::RR->new(
-            q{.        0 IN NSEC3 1 0 1 ab 01234567 A RRSIG}
-        );
-        is( $example->covers("example"), undef );
-    }
+    # NSEC3 resource record whose owner name is the root name. This should
+    # normally not happen.
+    $example = Zonemaster::LDNS::RR->new(
+        q{.        0 IN NSEC3 1 0 1 ab 01234567 A RRSIG}
+    );
+    is( $example->covers("example"), undef );
 };
 
 SKIP: {

--- a/t/dnssec.t
+++ b/t/dnssec.t
@@ -65,10 +65,7 @@ my $nsec3 = Zonemaster::LDNS::RR->new('NR2E513KM693MBTNVHH56ENF54F886T0.com. 864
 isa_ok($nsec3, 'Zonemaster::LDNS::RR::NSEC3');
 ok($nsec3->covers('xx-example.com'), 'Covers xx-example.com');
 
-SKIP: {
-    skip 'guaranteed crash', 1;
-    is($nsec3->covers('.'), undef, 'Does not cover the root domain');
-}
+is($nsec3->covers('.'), undef, 'Does not cover the root domain');
 
 subtest 'malformed NSEC3 do not cover anything' => sub {
     SKIP: {


### PR DESCRIPTION
## Purpose

This PR adds some input validation to the Zonemaster::LDNS::RR::NSEC3 package’s `covers` method.

## Context

Fix #174 and #175.

## Changes

* Add unit tests involving bad NSEC3 resource records and bad uses of Zonemaster::LDNS::RR::NSEC3::covers().
* Ensure the `covers()` method returns `undef`, instead of crashing, in the following cases:
  * The NSEC3 resource record has an empty next hashed owner name field in its RDATA: a malformed NSEC3 record cannot prove the absence of anything,
  * The `covers()` method is called with the root zone as argument: the root zone always exists and no NSEC3 record can ever prove its absence.

## How to test this PR

Unit tests were added, so all unit tests should pass.
