### PR TITLE
Travis: test with Perl 5.36, drop 5.14.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ env:
 
 language: perl
 perl:
-    - "5.32"
+    - "5.36"
     - "5.30.2"
     - "5.26"
-    - "5.14.4"
 
 before_install:
       # quoting preserves newlines in the script and then avoid error if the


### PR DESCRIPTION
Update Perl versions in Travis in order to match the versions we officially support.

## Purpose

This PR updates the Perl versions in Travis in order to match the versions we officially support.

## Context

Preparation of PR zonemaster/zonemaster-engine#1305.

## Changes

- Add Perl 5.36 and drop 5.14.4 from the list of Perl versions to test.

## How to test this PR

The CI workflow should pass.
