### PR TITLE
Update perl version to be tested by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
       # script contains comments
     - eval "$(curl https://travis-perl.github.io/init)"
     - sudo apt-get install -y libidn2-dev
-    - cpan-install --deps Devel::CheckLib Module::Install Module::Install::XSUtil
+    - cpan-install --deps Devel::CheckLib Module::Install Module::Install::XSUtil Test::Fatal
 
 install:
     - cpanm --verbose --notest --configure-args="--no-ed25519" .

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ env:
 
 language: perl
 perl:
-    - "5.36"
+    - "5.38"
+    - "5.34"
     - "5.30.2"
-    - "5.26"
 
 before_install:
       # quoting preserves newlines in the script and then avoid error if the

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: perl
 perl:
     - "5.38"
     - "5.34"
-    - "5.30"
+    - "5.30.2"
 
 before_install:
       # quoting preserves newlines in the script and then avoid error if the

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: perl
 perl:
     - "5.38"
     - "5.34"
-    - "5.30.2"
+    - "5.26"
 
 before_install:
       # quoting preserves newlines in the script and then avoid error if the

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: perl
 perl:
     - "5.38"
     - "5.34"
-    - "5.30.2"
+    - "5.30"
 
 before_install:
       # quoting preserves newlines in the script and then avoid error if the


### PR DESCRIPTION
## Purpose

This PR updates the Travis configuration file when it comes to Perl versions to be tested. The versions have been taken from the update in https://github.com/zonemaster/zonemaster/pull/1270

## Note

Travis fails if Perl is v5.30, but not if it is v5.30.2. For Zonemaster-CLI v5.30 works (https://github.com/zonemaster/zonemaster-cli/pull/373).

## How to test this PR

Review.