### PR TITLE
Extend CDS/CDNSKEY support

### DIFF
--- a/lib/Zonemaster/LDNS/RR/CDNSKEY.pm
+++ b/lib/Zonemaster/LDNS/RR/CDNSKEY.pm
@@ -3,7 +3,7 @@ package Zonemaster::LDNS::RR::CDNSKEY;
 use strict;
 use warnings;
 
-use parent 'Zonemaster::LDNS::RR';
+use parent 'Zonemaster::LDNS::RR::DNSKEY';
 
 1;
 
@@ -13,10 +13,12 @@ Zonemaster::LDNS::RR::CDNSKEY - Type CDNSKEY record
 
 =head1 DESCRIPTION
 
-A subclass of L<Zonemaster::LDNS::RR>, so it has all the methods of that class available in addition to the ones documented here.
+A subclass of L<Zonemaster::LDNS::RR::DNSKEY>, so it has all the methods of that class available in addition to the ones documented here.
 
 =head1 METHODS
 
-No RDATA methods implemented yet.
+No other specific methods implemented.
+
+Note that the inherited parent methods L<Zonemaster::LDNS::RR::DNSKEY/keytag()> and L<Zonemaster::LDNS::RR::DNSKEY/ds($hash)> will always return 0, as LDNS currently only supports the DNSKEY RR type for those methods.
 
 =cut

--- a/lib/Zonemaster/LDNS/RR/CDS.pm
+++ b/lib/Zonemaster/LDNS/RR/CDS.pm
@@ -3,7 +3,7 @@ package Zonemaster::LDNS::RR::CDS;
 use strict;
 use warnings;
 
-use parent 'Zonemaster::LDNS::RR';
+use parent 'Zonemaster::LDNS::RR::DS';
 
 1;
 
@@ -13,10 +13,12 @@ Zonemaster::LDNS::RR::CDS - Type CDS record
 
 =head1 DESCRIPTION
 
-A subclass of L<Zonemaster::LDNS::RR>, so it has all the methods of that class available in addition to the ones documented here.
+A subclass of L<Zonemaster::LDNS::RR::DS>, so it has all the methods of that class available in addition to the ones documented here.
 
 =head1 METHODS
 
-No RDATA methods implemented yet.
+No other specific methods implemented.
+
+Note that the inherited parent methods L<Zonemaster::LDNS::RR::DS/verify($other)> will always return false, as LDNS currently only supports the DS and DNSKEY RR types for this method.
 
 =cut

--- a/lib/Zonemaster/LDNS/RR/DNSKEY.pm
+++ b/lib/Zonemaster/LDNS/RR/DNSKEY.pm
@@ -94,6 +94,14 @@ Returns the algorithm number.
 
 Returns the cryptographic key in binary form.
 
+=item hexkeydata()
+
+Returns the cryptographic key as a hexadecimal string.
+
+=item keytag()
+
+Calculates the keytag.
+
 =item ds($hash)
 
 Returns a L<Zonemaster::LDNS::RR::DS> record matching this key. The argument must be one of the strings 'sha1', 'sha256', 'sha384' or 'gost'. GOST may not

--- a/lib/Zonemaster/LDNS/RR/DS.pm
+++ b/lib/Zonemaster/LDNS/RR/DS.pm
@@ -23,13 +23,13 @@ A subclass of L<Zonemaster::LDNS::RR>, so it has all the methods of that class a
 
 Returns the keytag value.
 
-=item digtype()
-
-Returns the numeric digest type.
-
 =item algorithm()
 
 Returns the algorithm number.
+
+=item digtype()
+
+Returns the numeric digest type.
 
 =item digest()
 

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -2012,6 +2012,16 @@ rr_dnskey_keydata(obj)
     OUTPUT:
         RETVAL
 
+char *
+rr_dnskey_hexkeydata(obj)
+    Zonemaster::LDNS::RR::DNSKEY obj;
+    CODE:
+        RETVAL = D_STRING(obj,3);
+    OUTPUT:
+        RETVAL
+    CLEANUP:
+        free(RETVAL);
+
 U16
 rr_dnskey_keytag(obj)
     Zonemaster::LDNS::RR::DNSKEY obj;


### PR DESCRIPTION
## Purpose

This PR extends the functionalities of `Zonemaster::LDNS::RR::{CDS, CDNSKEY}` resource records.

## Context

Fixes https://github.com/zonemaster/zonemaster-ldns/issues/114

Follow-up on #156 

## Changes

- `Zonemaster::LDNS::RR::CDS` and `Zonemaster::LDNS::RR::CDNSKEY` are now subclasses of `Zonemaster::LDNS::RR::DS` and `Zonemaster::LDNS::RR::DNSKEY`, respectively.
- Add method `Zonemaster::LDNS::RR::DNSKEY->hexkeydata()` (similar to `Zonemaster::LDNS::RR::DS->hexdigest()`)
- Add and update documentation
- Add and update unit tests

## How to test this PR

Unit tests are updated and should pass.

Manual testing:

```
$ perl -MZonemaster::LDNS -E 'my $rr = Zonemaster::LDNS::RR->new("cdnskey.test. 0 IN CDNSKEY 257 3 13 aa0b38f6755c2777992a74935d50a2a3480effef1a60bf8643d12c307465c9da"); say ref($rr); say $rr->string; say $rr->hexkeydata;'
Zonemaster::LDNS::RR::CDNSKEY
cdnskey.test.   0       IN      CDNSKEY 257 3 13 aa0b38f6755c2777992a74935d50a2a3480effef1a60bf8643d12c307465c9da
aa0b38f6755c2777992a74935d50a2a3480effef1a60bf8643d12c307465c9da
```
