### PR TITLE
Fix compiler warning in XS code

### DIFF
--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1732,7 +1732,7 @@ rr_check_rd_count(obj)
     Zonemaster::LDNS::RR obj;
     CODE:
         ldns_rr_type rr_type = ldns_rr_get_type(obj);
-        ldns_rr_descriptor *desc = ldns_rr_descript(rr_type);
+        const ldns_rr_descriptor *desc = ldns_rr_descript(rr_type);
         size_t rd_min = ldns_rr_descriptor_minimum(desc);
         size_t rd_max = ldns_rr_descriptor_maximum(desc);
         size_t rd_count = ldns_rr_rd_count(obj);


### PR DESCRIPTION
## Purpose

This PR fixes an easy-to-fix compiler warning when building Zonemaster::LDNS.

## Context

Not applicable.

## Changes

Turn a `ldns_rr_descriptor*` variable into a `const ldns_rr_descriptor*` variable.

## How to test this PR

On a checked-out Git repository, use `cpanm -nv .` and make sure no compiler warnings appear. Unit tests should also still pass.
