### PR TITLE
to_idn(): croak with locale-independent message

### DIFF
--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -28,7 +28,7 @@ to_idn(...)
                }
                else
                {
-                  croak("Error: %s\n", idn2_strerror(status));
+                  croak("IDN encoding error: %s\n", idn2_strerror_name(status));
                }
             }
         }

--- a/t/idn.t
+++ b/t/idn.t
@@ -25,6 +25,6 @@ is_deeply(
     'Many encoded right'
 );
 
-like( exception { to_idn( "ö" x 63 ) }, qr/Punycode/i, 'Boom today' );
+like( exception { to_idn( "ö" x 63 ) }, qr/IDN2_PUNYCODE_/i, 'croaks on IDN encoding failures' );
 
 done_testing;


### PR DESCRIPTION
## Purpose

This PR ensures changes `to_idn()` so that error conditions cause it to `croak` with a message that is not dependent on locale.

More details are in the commit message.

## Context

Fixes #104.

## Changes

Use [`idn2_strerror_name()`][1] instead of [`idn2_strerror()`][2] to build the error message. Update unit test accordingly.

## How to test this PR

Unit tests should pass.

[1]: https://www.gnu.org/software/libidn/libidn2/manual/libidn2.html#index-idn2_005fstrerror_005fname
[2]: https://www.gnu.org/software/libidn/libidn2/manual/libidn2.html#index-idn2_005fstrerror