### PR TITLE
Deprecate case randomization feature

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,7 +39,7 @@ Enabled by default.
 
 =item --[no-]randomize
 
-Experimental.
+This feature is deprecated and will be removed in Zonemaster 2025.1.
 Randomizes the capitalization of returned domain names.
 Disabled by default.
 
@@ -298,6 +298,7 @@ else {
 
 if ( $opt_randomize ) {
     print "Feature randomized capitalization enabled\n";
+    print "WARNING: This feature is DEPRECATED and will be removed in Zonemaster v2025.1.\n";
     cc_define '-DRANDOMIZE';
 }
 else {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   * [Ed25519]
   * [IDN]
   * [Internal ldns]
-  * [Randomized capitalization](#randomized-capitalization)
+  * [Randomized capitalization (deprecated)](#randomized-capitalization-deprecated)
   * [Custom OpenSSL]
   * [Custom LDNS]
   * [Custom Libidn]
@@ -166,12 +166,12 @@ When enabled, an included version of ldns is statically linked into
 Zonemaster::LDNS.
 When disabled, libldns is dynamically linked just like other dependencies.
 
-### Randomized capitalization
+### Randomized capitalization (deprecated)
 
 Disabled by default.
 Enable with `--randomize`.
 
-> **Note:** This feature is experimental.
+> **Note:** This feature is deprecated and will be removed in Zonemaster 2025.1.
 
 Randomizes the capitalization of returned domain names.
 

--- a/src/assist.c
+++ b/src/assist.c
@@ -184,6 +184,7 @@ char *
 randomize_capitalization(char *in)
 {
 #ifdef RANDOMIZE
+#warning "Case randomization is deprecated and will be removed in v2025.1."
     char *str;
     str = in;
     while(*str) {

--- a/t/rr.t
+++ b/t/rr.t
@@ -1,3 +1,5 @@
+use v5.16;
+
 use Test::More;
 use Test::Fatal;
 use Devel::Peek;
@@ -67,7 +69,7 @@ subtest 'AAAA' => sub {
     SKIP: {
         skip 'no network', 1 unless $ENV{TEST_WITH_NETWORK};
 
-        $p = $s->query( 'a.ns.se', 'AAAA' );
+        my $p = $s->query( 'a.ns.se', 'AAAA' );
         plan skip_all => 'No response, cannot test' if not $p;
 
         foreach my $rr ( $p->answer ) {
@@ -286,7 +288,7 @@ subtest 'SPF' => sub {
 subtest 'DNAME' => sub {
     my $rr = Zonemaster::LDNS::RR->new( 'examplë.fake 3600  IN  DNAME example.fake' );
     isa_ok( $rr, 'Zonemaster::LDNS::RR::DNAME' );
-    is($rr->dname(), 'example.fake.');
+    is(fc($rr->dname()), fc('example.fake.'));
 };
 
 subtest 'croak when given malformed CAA records' => sub {
@@ -297,7 +299,7 @@ subtest 'croak when given malformed CAA records' => sub {
         # This will always croak
         $bad_caa->string();
     };
-    like( exception { $will_croak->() }, qr/^Failed to convert RR to string/ );
+    like( exception(sub { $will_croak->() }), qr/^Failed to convert RR to string/ );
 };
 
 done_testing;


### PR DESCRIPTION
## Purpose

This PR adds deprecation warnings for the experimental (and thus also seemingly untested) case randomization feature that can be optionally compiled in Zonemaster::LDNS.

## Context

See issue #160.

## Changes

Warn end users about the upcoming removal of this feature in three places:

- the documentation;
- the `Makefile.PL` script;
- and the C code.

## How to test this PR

In the root of the source tree of Zonemaster::LDNS, run `cpanm -v --configure-args="--random" .`.

In the first 30 lines of the console output, expect:
```
Feature randomized capitalization enabled
WARNING: This feature is DEPRECATED and will be removed in Zonemaster v2025.1.
```

During the build stage, also expect a compiler-generated warning like so:
```
src/assist.c: In function ‘randomize_capitalization’:
src/assist.c:187:2: warning: #warning "Case randomization is deprecated and will be removed in v2025.1." [-Wcpp]
```

Expect unit tests to pass.

Then, run `cpanm -v .`. Expect none of the aforementioned deprecation warnings to appear in the output, and expect unit tests to pass.