### PR TITLE
Remove feature "randomized capitalization"

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -40,12 +40,6 @@ Zonemaster::LDNS.
 When disabled, libldns is dynamically linked just like other dependencies.
 Enabled by default.
 
-=item --[no-]randomize
-
-This feature is deprecated and will be removed in Zonemaster 2025.1.
-Randomizes the capitalization of returned domain names.
-Disabled by default.
-
 =item --prefix-openssl=PATH
 
 Search for OpenSSL headers and libraries in PATH.
@@ -88,7 +82,6 @@ Enable debug mode, more verbose output.
 my $opt_ed25519        = 1;
 my $opt_idn            = 1;
 my $opt_internal_ldns  = 1;
-my $opt_randomize      = 0;
 my $opt_debug          = 0;
 my $opt_assets         = {
     openssl => {
@@ -110,7 +103,6 @@ GetOptions(
     'ed25519!'         => \$opt_ed25519,
     'idn!'             => \$opt_idn,
     'internal-ldns!'   => \$opt_internal_ldns,
-    'randomize!'       => \$opt_randomize,
     'debug!'           => \$opt_debug,
     'prefix-openssl=s' => \$$opt_assets{openssl}{prefix},
     'openssl-inc=s'    => \$$opt_assets{openssl}{inc},
@@ -316,19 +308,6 @@ if ( $opt_idn ) {
 else {
     print "Feature idn disabled\n";
 }
-
-
-# Internals
-
-if ( $opt_randomize ) {
-    print "Feature randomized capitalization enabled\n";
-    print "WARNING: This feature is DEPRECATED and will be removed in Zonemaster v2025.1.\n";
-    cc_define '-DRANDOMIZE';
-}
-else {
-    print "Feature randomized capitalization disabled\n";
-}
-
 
 sub MY::postamble {
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
   * [Ed25519]
   * [IDN]
   * [Internal ldns]
-  * [Randomized capitalization (deprecated)](#randomized-capitalization-deprecated)
   * [Custom OpenSSL]
   * [Custom LDNS]
   * [Custom Libidn]
@@ -166,16 +165,6 @@ Disable with `--no-internal-ldns`.
 When enabled, an included version of ldns is statically linked into
 Zonemaster::LDNS.
 When disabled, libldns is dynamically linked just like other dependencies.
-
-### Randomized capitalization (deprecated)
-
-Disabled by default.
-Enable with `--randomize`.
-
-> **Note:** This feature is deprecated and will be removed in Zonemaster 2025.1.
-
-Randomizes the capitalization of returned domain names.
-
 
 ### Custom OpenSSL
 

--- a/include/LDNS.h
+++ b/include/LDNS.h
@@ -107,7 +107,6 @@ typedef ldns_rr *Zonemaster__LDNS__RR__X25;
 #define D_U32(what,where) ldns_rdf2native_int32(ldns_rr_rdf(what,where))
 
 SV *rr2sv(ldns_rr *rr);
-char *randomize_capitalization(char *in);
 void strip_newline(char* in);
 
 #ifdef USE_ITHREADS

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -512,7 +512,7 @@ addr2name(obj,addr_in)
             {
                 ldns_rr *rr = ldns_rr_list_rr(names,i);
                 ldns_rdf *name_rdf = ldns_rr_rdf(rr,0);
-                char *name_str = randomize_capitalization(ldns_rdf2str(name_rdf));
+                char *name_str = ldns_rdf2str(name_rdf);
 
                 SV* sv = newSVpv(name_str,0);
                 mXPUSHs(sv);
@@ -1738,7 +1738,7 @@ char *
 rr_owner(obj)
     Zonemaster::LDNS::RR obj;
     CODE:
-        RETVAL = randomize_capitalization(ldns_rdf2str(ldns_rr_owner(obj)));
+        RETVAL = ldns_rdf2str(ldns_rr_owner(obj));
     OUTPUT:
         RETVAL
     CLEANUP:
@@ -1888,7 +1888,7 @@ char *
 rr_ns_nsdname(obj)
     Zonemaster::LDNS::RR::NS obj;
     CODE:
-        RETVAL = randomize_capitalization(ldns_rdf2str(ldns_rr_rdf(obj, 0)));
+        RETVAL = ldns_rdf2str(ldns_rr_rdf(obj, 0));
     OUTPUT:
         RETVAL
     CLEANUP:
@@ -1909,7 +1909,7 @@ char *
 rr_mx_exchange(obj)
     Zonemaster::LDNS::RR::MX obj;
     CODE:
-        RETVAL = randomize_capitalization(D_STRING(obj, 1));
+        RETVAL = D_STRING(obj, 1);
     OUTPUT:
         RETVAL
     CLEANUP:
@@ -1948,7 +1948,7 @@ char *
 rr_soa_mname(obj)
     Zonemaster::LDNS::RR::SOA obj;
     CODE:
-        RETVAL = randomize_capitalization(D_STRING(obj,0));
+        RETVAL = D_STRING(obj,0);
     OUTPUT:
         RETVAL
     CLEANUP:
@@ -1958,7 +1958,7 @@ char *
 rr_soa_rname(obj)
     Zonemaster::LDNS::RR::SOA obj;
     CODE:
-        RETVAL = randomize_capitalization(D_STRING(obj,1));
+        RETVAL = D_STRING(obj,1);
     OUTPUT:
         RETVAL
     CLEANUP:
@@ -2324,7 +2324,7 @@ char *
 rr_nsec_next(obj)
     Zonemaster::LDNS::RR::NSEC obj;
     CODE:
-        RETVAL = randomize_capitalization(D_STRING(obj,0));
+        RETVAL = D_STRING(obj,0);
     OUTPUT:
         RETVAL
 
@@ -2654,7 +2654,7 @@ char *
 rr_ptr_ptrdname(obj)
     Zonemaster::LDNS::RR::PTR obj;
     CODE:
-        RETVAL = randomize_capitalization(D_STRING(obj,0));
+        RETVAL = D_STRING(obj,0);
     OUTPUT:
         RETVAL
     CLEANUP:
@@ -2667,7 +2667,7 @@ char *
 rr_cname_cname(obj)
     Zonemaster::LDNS::RR::CNAME obj;
     CODE:
-        RETVAL = randomize_capitalization(D_STRING(obj,0));
+        RETVAL = D_STRING(obj,0);
     OUTPUT:
         RETVAL
     CLEANUP:
@@ -2679,7 +2679,7 @@ char *
 rr_dname_dname(obj)
     Zonemaster::LDNS::RR::DNAME obj;
     CODE:
-        RETVAL = randomize_capitalization(D_STRING(obj,0));
+        RETVAL = D_STRING(obj,0);
     OUTPUT:
         RETVAL
     CLEANUP:

--- a/src/assist.c
+++ b/src/assist.c
@@ -180,28 +180,6 @@ net_ldns_clone_packets()
 
 #endif
 
-char *
-randomize_capitalization(char *in)
-{
-#ifdef RANDOMIZE
-#warning "Case randomization is deprecated and will be removed in v2025.1."
-    char *str;
-    str = in;
-    while(*str) {
-        if(Drand01() < 0.5)
-        {
-            *str = tolower(*str);
-        }
-        else
-        {
-            *str = toupper(*str);
-        }
-        str++;
-    }
-#endif
-    return in;
-}
-
 SV *
 rr2sv(ldns_rr *rr)
 {

--- a/t/rr.t
+++ b/t/rr.t
@@ -394,7 +394,7 @@ subtest 'SPF' => sub {
 subtest 'DNAME' => sub {
     my $rr = Zonemaster::LDNS::RR->new( 'examplë.fake 3600  IN  DNAME example.fake' );
     isa_ok( $rr, 'Zonemaster::LDNS::RR::DNAME' );
-    is(fc($rr->dname()), fc('example.fake.'));
+    is($rr->dname(), 'example.fake.');
 };
 
 subtest 'croak when given malformed CAA records' => sub {


### PR DESCRIPTION
## Purpose

This PR removes an experimental and previously deprecated “randomized capitalization” feature from Zonemaster-LDNS.

## Context

See #160 for the issue and discussion, and #206 for the initial deprecation warnings.

## Changes

Remove the “randomized capitalization” feature from Zonemaster-LDNS. Update the documentation accordingly.

## How to test this PR

In the root of the source tree of Zonemaster::LDNS, run cpanm -v --configure-args="--random" .

Among the roughly 30 first lines of output, expect this output (the version number of `Zonemaster-LDNS` may vary):
```
Configuring Zonemaster-LDNS-4.0.2 ... Unknown option: random
```

Also, expect unit tests (which have been updated) to pass.