### PR TITLE
Allow construction of empty Zonemaster::LDNS::RRList objects

### DIFF
--- a/lib/Zonemaster/LDNS/RRList.pm
+++ b/lib/Zonemaster/LDNS/RRList.pm
@@ -31,6 +31,12 @@ Zonemaster::LDNS::RRList - class representing lists of resource records.
 
 =over
 
+=item new()
+
+Creates a new empty L<Zonemaster::LDNS::RRList> object.
+
+=back
+
 =item new($rrs)
 
 Creates a new L<Zonemaster::LDNS::RRList> object for the given resource records.

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1558,13 +1558,8 @@ rrlist_new(objclass,rrs_in)
     AV *rrs_in;
     CODE:
     {
-        size_t i;
+        SSize_t i;
         ldns_rr_list *rrs = ldns_rr_list_new();
-
-        if(av_len(rrs_in)==-1)
-        {
-           croak("List is empty");
-        }
 
         /* Take RRs out of the array and stick them in a list */
         for(i = 0; i <= av_len(rrs_in); ++i)
@@ -1675,7 +1670,7 @@ rrlist_string(obj)
     Zonemaster::LDNS::RRList obj;
     CODE:
         RETVAL = ldns_rr_list2str(obj);
-        if(RETVAL == NULL || RETVAL[0] == '\0')
+        if(RETVAL == NULL)
         {
             croak("Failed to convert RRList to string");
         }

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1553,30 +1553,34 @@ packet_CLONE(class)
 MODULE = Zonemaster::LDNS        PACKAGE = Zonemaster::LDNS::RRList           PREFIX=rrlist_
 
 SV *
-rrlist_new(objclass,rrs_in)
+rrlist_new(objclass, ...)
     char* objclass;
-    AV *rrs_in;
     CODE:
     {
-        SSize_t i;
+        AV *rrs_in = NULL;
         ldns_rr_list *rrs = ldns_rr_list_new();
 
         /* Take RRs out of the array and stick them in a list */
-        for(i = 0; i <= av_len(rrs_in); ++i)
-        {
-            ldns_rr *rr;
-            SV **rrsv = av_fetch(rrs_in,i,1);
-            if (rrsv != NULL && sv_isobject(*rrsv) && sv_derived_from(*rrsv, "Zonemaster::LDNS::RR")) {
-                SvGETMAGIC(*rrsv);
-                IV tmp = SvIV((SV*)SvRV(*rrsv));
-                rr = INT2PTR(ldns_rr *,tmp);
-                if(rr != NULL)
-                {
-                    ldns_rr_list_push_rr(rrs, ldns_rr_clone(rr));
+        if (items > 1) {
+            SSize_t i;
+            rrs_in = (AV *) SvRV(ST(1));
+
+            for(i = 0; i <= av_len(rrs_in); ++i)
+            {
+                ldns_rr *rr;
+                SV **rrsv = av_fetch(rrs_in,i,1);
+                if (rrsv != NULL && sv_isobject(*rrsv) && sv_derived_from(*rrsv, "Zonemaster::LDNS::RR")) {
+                    SvGETMAGIC(*rrsv);
+                    IV tmp = SvIV((SV*)SvRV(*rrsv));
+                    rr = INT2PTR(ldns_rr *,tmp);
+                    if(rr != NULL)
+                    {
+                        ldns_rr_list_push_rr(rrs, ldns_rr_clone(rr));
+                    }
                 }
-            }
-            else {
-                croak("Incorrect type in list");
+                else {
+                    croak("Incorrect type in list");
+                }
             }
         }
 

--- a/t/rrlist.t
+++ b/t/rrlist.t
@@ -4,7 +4,6 @@ use warnings;
 use Test::More;
 use Test::Exception;
 use Test::Differences;
-use Devel::Peek;
 
 use Zonemaster::LDNS;
 

--- a/t/rrlist.t
+++ b/t/rrlist.t
@@ -1,9 +1,39 @@
+use strict;
+use warnings;
+
 use Test::More;
 use Test::Exception;
 use Test::Differences;
 use Devel::Peek;
 
 use Zonemaster::LDNS;
+
+subtest "Empty RRList" => sub {
+    my $empty_a = Zonemaster::LDNS::RRList->new([]);
+    my $empty_b = Zonemaster::LDNS::RRList->new([]);
+    my $nonempty = Zonemaster::LDNS::RRList->new([
+        Zonemaster::LDNS::RR->new_from_string('test. 0 IN TXT "hello"')
+    ]);
+
+    isa_ok($empty_a, 'Zonemaster::LDNS::RRList');
+    isa_ok($empty_b, 'Zonemaster::LDNS::RRList');
+    isa_ok($nonempty, 'Zonemaster::LDNS::RRList');
+
+    eq_or_diff( $empty_a->string, '', "stringifying an empty list gives empty string" );
+    ok( $empty_a eq $empty_b, "two distinct empty RRLists are equal to each other" );
+    ok( $empty_a ne $nonempty, "an empty RRlist is not equal to a non-empty RRlist" );
+
+    $nonempty->pop();
+    ok( $empty_a eq $nonempty, "now both lists are empty" );
+
+    is( $empty_a->count(), 0, "count() on empty list is 0" );
+
+    is( $empty_a->get(0), undef, "get(0) on empty list gives undef" );
+    is( $empty_a->get(42), undef, "get(42) on empty list also gives undef" );
+
+    ok( !$empty_a->is_rrset(), "an empty list is not an RRset" );
+    ok( !$empty_b->is_rrset(), "an empty list is not an RRset" );
+};
 
 subtest "Good RRList" => sub {
     my $rr1 = Zonemaster::LDNS::RR->new_from_string( 'example. 10 IN NS ns1.example.' );

--- a/t/rrlist.t
+++ b/t/rrlist.t
@@ -8,30 +8,39 @@ use Test::Differences;
 use Zonemaster::LDNS;
 
 subtest "Empty RRList" => sub {
-    my $empty_a = Zonemaster::LDNS::RRList->new();
-    my $empty_b = Zonemaster::LDNS::RRList->new([]);
-    my $nonempty = Zonemaster::LDNS::RRList->new([
+    my $empty_impl = Zonemaster::LDNS::RRList->new();
+    my $empty_expl = Zonemaster::LDNS::RRList->new([]);
+    my $singleton = Zonemaster::LDNS::RRList->new([
         Zonemaster::LDNS::RR->new_from_string('test. 0 IN TXT "hello"')
     ]);
 
-    isa_ok($empty_a, 'Zonemaster::LDNS::RRList');
-    isa_ok($empty_b, 'Zonemaster::LDNS::RRList');
-    isa_ok($nonempty, 'Zonemaster::LDNS::RRList');
+    isa_ok($empty_impl, 'Zonemaster::LDNS::RRList');
+    isa_ok($empty_expl, 'Zonemaster::LDNS::RRList');
+    isa_ok($singleton, 'Zonemaster::LDNS::RRList');
 
-    eq_or_diff( $empty_a->string, '', "stringifying an empty list gives empty string" );
-    ok( $empty_a eq $empty_b, "two distinct empty RRLists are equal to each other" );
-    ok( $empty_a ne $nonempty, "an empty RRlist is not equal to a non-empty RRlist" );
+    # We really want to make sure that new() and new([]) have the same
+    # semantics.
 
-    $nonempty->pop();
-    ok( $empty_a eq $nonempty, "now both lists are empty" );
+    ok( $empty_impl eq $empty_expl, "two distinct empty RRLists are equal to each other" );
+    ok( $empty_expl eq $empty_impl, "eq on two empty lists is commutative" );
 
-    is( $empty_a->count(), 0, "count() on empty list is 0" );
+    eq_or_diff( $empty_impl->string, '', "stringifying an implicitly empty list gives empty string" );
+    eq_or_diff( $empty_expl->string, '', "stringifying an explicitly empty list gives empty string" );
 
-    is( $empty_a->get(0), undef, "get(0) on empty list gives undef" );
-    is( $empty_a->get(42), undef, "get(42) on empty list also gives undef" );
+    ok( $empty_impl ne $singleton, "the implicitly empty list isn’t equal to a non-empty one" );
+    ok( $empty_expl ne $singleton, "the explicitly empty list isn’t equal to a non-empty one" );
 
-    ok( !$empty_a->is_rrset(), "an empty list is not an RRset" );
-    ok( !$empty_b->is_rrset(), "an empty list is not an RRset" );
+    $singleton->pop();
+    ok( $empty_impl eq $singleton, "now both lists are empty" );
+
+    is( $empty_impl->count(), 0, "count() on implicitly empty list is 0" );
+    is( $empty_expl->count(), 0, "count() on explicitly empty list is 0" );
+
+    is( $empty_impl->get(0), undef, "get(0) on empty list gives undef" );
+    is( $empty_impl->get(42), undef, "get(42) on empty list also gives undef" );
+
+    ok( !$empty_impl->is_rrset(), "an empty list is not an RRset" );
+    ok( !$empty_expl->is_rrset(), "an empty list is not an RRset" );
 };
 
 subtest "Good RRList" => sub {

--- a/t/rrlist.t
+++ b/t/rrlist.t
@@ -9,7 +9,7 @@ use Devel::Peek;
 use Zonemaster::LDNS;
 
 subtest "Empty RRList" => sub {
-    my $empty_a = Zonemaster::LDNS::RRList->new([]);
+    my $empty_a = Zonemaster::LDNS::RRList->new();
     my $empty_b = Zonemaster::LDNS::RRList->new([]);
     my $nonempty = Zonemaster::LDNS::RRList->new([
         Zonemaster::LDNS::RR->new_from_string('test. 0 IN TXT "hello"')


### PR DESCRIPTION
## Purpose

This PR addresses a design oversight in the constructor for Zonemaster::LDNS::RRList objects. It was for now assumed that it would always be used to construct nonempty RRList objects, but a PR in Zonemaster-Engine elicited the need for exactly that use case.

## Context

Follow-up to #203; review of https://github.com/zonemaster/zonemaster-engine/pull/1383.

## Changes

Allow calling Zonemaster::LDNS::RRList::new() with either no argument or an empty arrayref.

## How to test this PR

Unit tests were added, and should therefore pass.
