### PR TITLE
Use ExtUtils::PkgConfig to discover the CFLAGS and LDFLAGS for external libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: sudo apt install -y libidn2-dev
 
       - name: cpan module
-        run: cpanm Module::Install Devel::CheckLib Module::Install::XSUtil Test::Fatal Test::Exception
+        run: cpanm Devel::CheckLib ExtUtils::PkgConfig Module::Install Module::Install::XSUtil Test::Exception Test::Fatal 
 
       - name: installation
         run: cpanm --verbose --notest --configure-args="--no-ed25519" .

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
       # script contains comments
     - eval "$(curl https://travis-perl.github.io/init)"
     - sudo apt-get install -y libidn2-dev
-    - cpan-install --deps Devel::CheckLib Module::Install Module::Install::XSUtil Test::Fatal
+    - cpan-install --deps Devel::CheckLib ExtUtils::PkgConfig Module::Install Module::Install::XSUtil Test::Fatal
 
 install:
     - cpanm --verbose --notest --configure-args="--no-ed25519" .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache \
     perl-app-cpanminus \
     perl-dev \
     perl-devel-checklib \
+    perl-extutils-pkgconfig \
     perl-lwp-protocol-https \
     perl-module-install \
     perl-test-fatal \

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,10 @@
+use v5.14;
+
 use inc::Module::Install;
 use Devel::CheckLib;
-use Getopt::Long;
+use ExtUtils::PkgConfig;
 use File::Spec::Functions;
+use Getopt::Long;
 
 BEGIN {
     if ( $Module::Install::AUTHOR ) {
@@ -119,6 +122,7 @@ GetOptions(
 );
 
 configure_requires 'Devel::CheckLib'         => 0;
+configure_requires 'ExtUtils::PkgConfig'     => 0;
 configure_requires 'Module::Install'         => 1.19;
 configure_requires 'Module::Install::XSUtil' => 0;
 #
@@ -145,13 +149,14 @@ sub custom_assets
     my ( $href ) = @_;
     # $href = { key => "openssl", lib => "crypto", name => "OpenSSL" }
 
-    my $key  = $$href{key};
-    my $name = $$href{name};
-    my $lib  = $$href{lib};
+    my $key    = $href->{key};
+    my $name   = $href->{name};
+    my $lib    = $href->{lib};
+    my $pcname = $href->{pcname};
 
-    my $input_prefix = $$opt_assets{$key}{prefix};
-    my $input_inc    = $$opt_assets{$key}{inc};
-    my $input_lib    = $$opt_assets{$key}{lib};
+    my $input_prefix = $opt_assets->{$key}{prefix};
+    my $input_inc    = $opt_assets->{$key}{inc};
+    my $input_lib    = $opt_assets->{$key}{lib};
 
     my $custom_lib = ( $input_prefix or $input_inc or $input_lib );
     if ( $custom_lib ) {
@@ -181,7 +186,22 @@ sub custom_assets
         $assert_lib_args{$key}{libpath} = "$libpath";
     }
     else {
-        cc_libs "$lib";
+        my %pkg_info = eval { ExtUtils::PkgConfig->find($pcname); };
+        if ($@) {
+            warn "$@\n";
+            say "Guessing LDFLAGS for $name: -l${lib}";
+            cc_libs $lib;
+        }
+        else {
+            if ((my $cflags = $pkg_info{cflags}) ne '') {
+                say "Adding CFLAGS for $name using pkg-config: $cflags";
+                cc_include_paths $cflags;
+            }
+            if ((my $libs = $pkg_info{libs}) ne '') {
+                say "Adding LDFLAGS for $name using pkg-config: $libs";
+                cc_libs $libs;
+            }
+        }
     }
 }
 
@@ -189,9 +209,10 @@ sub custom_assets
 
 custom_assets(
     {
-        name => "OpenSSL",
-        lib  => "crypto",
-        key  => "openssl"
+        name   => "OpenSSL",
+        lib    => "crypto",
+        key    => "openssl",
+        pcname => "openssl"
     }
 );
 
@@ -232,9 +253,10 @@ else {
 
     custom_assets(
         {
-            name => "LDNS",
-            lib  => "ldns",
-            key  => "ldns"
+            name   => "LDNS",
+            lib    => "ldns",
+            key    => "ldns",
+            pcname => "libldns"
         }
     );
 
@@ -275,9 +297,10 @@ if ( $opt_idn ) {
 
     custom_assets(
         {
-            name => "Libidn",
-            lib  => "idn2",
-            key  => "libidn"
+            name   => "Libidn",
+            lib    => "idn2",
+            key    => "libidn",
+            pcname => "libidn2"
         }
     );
 

--- a/t/rr.t
+++ b/t/rr.t
@@ -206,7 +206,7 @@ subtest 'NSEC' => sub {
             ok( $rr->typehref->{TXT} );
             ok( !$rr->typehref->{MX} );
             ok( $rr->typehref->{TXT} );
-            is( $rr->typelist, 'NS SOA TXT RRSIG NSEC DNSKEY ' );
+            is( $rr->typelist, 'NS SOA TXT RRSIG NSEC DNSKEY ZONEMD ' );
         }
     }
 };


### PR DESCRIPTION
## Purpose

This PR aims to make detection of CFLAGS and LDFLAGS more reliable and portable across \*nix systems by calling out to `pkg-config`. By doing so, libraries that have been installed by hand (in `/usr/local` or a private prefix such as `$HOME/.local`) or through alternative package managers are more likely to be successfully detected.

## Context

See #129.

## Changes

 * Use ExtUtils::PkgConfig to detect CFLAGS and LDFLAGS for libraries we link against.
 * Install ExtUtils::PkgConfig in the build environment when generating the Docker image.

## How to test this PR

Run `perl Makefile.PL`; it should still work.

Building the Dockerfile should also still work.
