### PR TITLE
Document new dependency on ExtUtils::PkgConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Run-time dependencies:
 Compile-time dependencies (only when installing from source):
  * `make`
  * `Devel::CheckLib`
+ * `ExtUtils::PkgConfig`
  * `Module::Install`
  * `Module::Install::XSUtil`
  * `Test::More >= 1.302015`


### PR DESCRIPTION
## Purpose

This PR documents the change introduced in #210 in README.md.

## Context

Follow-up to #210.

## Changes

Add ExtUtils::PkgConfig to the dependencies listed in README.md.

## How to test this PR

N/A.
