### PR TITLE
Makefile.PL: set include paths correctly

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -187,12 +187,13 @@ sub custom_assets {
             cc_libs $lib;
         }
         else {
-            if ( ( my $cflags = $pkg_info{cflags} ) ne '' ) {
-                say "Adding CFLAGS for $name using pkg-config: $cflags";
-                cc_include_paths $cflags;
+            if ( defined ( my $includes = ExtUtils::PkgConfig->cflags_only_I($pcname) ) ) {
+                my @inc = map { s/^-I//r } (split /\s+/, $includes);
+                say "Adding include paths for $name using pkg-config: " . join(", ", @inc);
+                cc_include_paths @inc;
             }
             if ( ( my $libs = $pkg_info{libs} ) ne '' ) {
-                say "Adding LDFLAGS for $name using pkg-config: $libs";
+                say "Adding library paths and names for $name using pkg-config: $libs";
                 cc_libs $libs;
             }
         }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -194,7 +194,7 @@ sub custom_assets {
             }
             if ( ( my $libs = $pkg_info{libs} ) ne '' ) {
                 say "Adding library paths and names for $name using pkg-config: $libs";
-                cc_libs $libs;
+                cc_libs (split /\s+/, $libs);
             }
         }
     }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -261,6 +261,10 @@ else {
         }
     );
 
+    # LDNS needs OpenSSL, so we need openssl’s compiler flags for ldns too
+    push @{$assert_lib_args{ldns}{$_}}, @{$assert_lib_args{openssl}{$_}}
+        for ( qw(incpath libpath) );
+
     if ( $opt_ed25519 ) {
         cc_assert_lib(
             debug  => $opt_debug,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -188,19 +188,20 @@ sub custom_assets {
         }
         else {
             if ( defined ( my $includes = ExtUtils::PkgConfig->cflags_only_I($pcname) ) ) {
-                my @inc = map { s/^-I//r } (split /\s+/, $includes);
+                my @inc = map { s/^-I//r } (split " ", $includes);
                 say "Adding include paths for $name using pkg-config: " . join(", ", @inc);
 
                 cc_include_paths @inc;
                 $assert_lib_args{$key}{incpath} = \@inc;
             }
-            if ( ( my $libs = $pkg_info{libs} ) ne '' ) {
-                say "Adding library paths and names for $name using pkg-config: $libs";
-                my @libs = (split /\s+/, $libs);
-                my @libpaths = grep { /^-L/ } @libs;
+            if ( defined ( my $libs = ExtUtils::PkgConfig->libs($pcname) ) ) {
+                cc_libs (split " ", $libs);
+            }
+            if ( defined ( my $libpaths = ExtUtils::PkgConfig->libs_only_L($pcname) ) ) {
+                my @libpaths = map { s/^-L//r } (split " ", $libpaths);
+                say "Adding library paths for $name using pkg-config: " . join(", ", @libpaths);
 
-                cc_libs @libs;
-                $assert_lib_args{$key}{libpath} = \@libs;
+                $assert_lib_args{$key}{libpath} = \@libpaths;
             }
         }
     }
@@ -319,6 +320,7 @@ else {
 # OpenSSL with SHA-1 support
 
 check_lib(
+    debug    => $opt_debug,
     header   => [ 'openssl/crypto.h', 'openssl/evp.h', 'openssl/x509.h' ],
     lib      => 'crypto',
     function => q{
@@ -386,6 +388,7 @@ check_lib(
         EVP_PKEY_free(pkey);
         return ok ? 0 : 1;
     },
+    %{ $assert_lib_args{openssl} },
   )
   or do {
     print STDERR "wrong result: Failed to verify cryptographic SHA-1 support in OpenSSL.\n"

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -190,11 +190,17 @@ sub custom_assets {
             if ( defined ( my $includes = ExtUtils::PkgConfig->cflags_only_I($pcname) ) ) {
                 my @inc = map { s/^-I//r } (split /\s+/, $includes);
                 say "Adding include paths for $name using pkg-config: " . join(", ", @inc);
+
                 cc_include_paths @inc;
+                $assert_lib_args{$key}{incpath} = \@inc;
             }
             if ( ( my $libs = $pkg_info{libs} ) ne '' ) {
                 say "Adding library paths and names for $name using pkg-config: $libs";
-                cc_libs (split /\s+/, $libs);
+                my @libs = (split /\s+/, $libs);
+                my @libpaths = grep { /^-L/ } @libs;
+
+                cc_libs @libs;
+                $assert_lib_args{$key}{libpath} = \@libs;
             }
         }
     }


### PR DESCRIPTION
## Purpose

This PR addresses an oversight in #210 that causes Makefile.PL to fail when a library needs include paths (`-I`) specified on the compiler command line.

## Context

See:

 - #129 and [this comment](https://github.com/zonemaster/zonemaster-ldns/issues/129#issuecomment-2496117623)

## Changes

Filter the output of `pkg-config` to turn it into a list of raw paths, for consumption by `cc_include_paths` from Module::Install::XSUtil.

## How to test this PR

Run Makefile.PL, ideally while having OpenSSL or LDNS installed in a custom location such as the user’s home directory.