### PR TITLE
Fix export of methods

### DIFF
--- a/lib/Zonemaster/LDNS.pm
+++ b/lib/Zonemaster/LDNS.pm
@@ -5,7 +5,7 @@ use 5.014;
 our $VERSION = '4.1.0';
 
 use parent 'Exporter';
-our @EXPORT_OK = qw[to_idn has_idn ldns_version load_zonefile];
+our @EXPORT_OK = qw[lib_version to_idn has_idn has_gost load_zonefile];
 our %EXPORT_TAGS = ( all => \@EXPORT_OK );
 
 require XSLoader;
@@ -37,7 +37,7 @@ C<Zonemaster::LDNS> represents a resolver, which is the part of the system respo
 
 =item lib_version()
 
-Returns the ldns version string. Can be exported, but is not by default.
+Returns the ldns version string.
 
 =item to_idn($name, ...)
 


### PR DESCRIPTION
## Purpose

This PR fixes export of some methods in `Zonemaster::LDNS`.

## Changes

- Method `lib_version` was wrongly exported to `ldns_version`
- Method `has_gost` was missing

## How to test this PR

Tests should pass. 
Manual testing:
```
$ perl -MZonemaster::LDNS=lib_version,has_gost -E 'say "version: ", lib_version(); say has_gost() ? "true" : "false"'
version: 1.8.3
has_gost: false
```
