### PR TITLE
Sets minimum Perl version to v5.26.0 (Zonemaster-LDNS)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -113,6 +113,8 @@ GetOptions(
     'ldns-lib=s'       => \$$opt_assets{ldns}{lib},
 );
 
+perl_version '5.026000'; # Perl v5.26.0 or higher is required for installation.
+
 configure_requires 'Devel::CheckLib'         => 0;
 configure_requires 'ExtUtils::PkgConfig'     => 0;
 configure_requires 'Module::Install'         => 1.19;


### PR DESCRIPTION
## Purpose

https://github.com/zonemaster/zonemaster-cli/pull/421 requires Perl version to be v5.26, and to meet that https://github.com/zonemaster/zonemaster/pull/1387 documents lowest Perl version to be v5.26. To be consistent all Zonemaster Perl components should require the same minimum version.

This PR updates Makefile.PL to require v5.26.0, which makes `cpanm` refuse to install if the Perl version is lower.

An alternative would be to add `use v5.26` to all Zonemaster Perl modules.

When (if) this PR is approved, RRs for the other components will be created.

## To consider

Is this a breaking change? The version is not higher than the lowest version of Perl in the tested OSs in the last couple of releases.

## Context

* https://github.com/zonemaster/zonemaster-cli/pull/421
* https://github.com/zonemaster/zonemaster/pull/1387

## How to test this PR

Review. Try to install on a system with lower version of Perl (should fail) and another with that version of Perl or higher (should pass).