### PR TITLE
Update Dockerfile for release 2025.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14 as build
+FROM alpine:3.22 as build
 
 RUN apk add --no-cache \
     # Compile-time dependencies
@@ -9,10 +9,14 @@ RUN apk add --no-cache \
     perl-app-cpanminus \
     perl-dev \
     perl-devel-checklib \
+    perl-extutils-depends \
     perl-extutils-pkgconfig \
     perl-lwp-protocol-https \
+    perl-mime-base32 \
     perl-module-install \
+    perl-test-differences \
     perl-test-fatal \
+    perl-test-nowarnings \
  && cpanm --notest --no-wget --from=https://cpan.metacpan.org/ \
     Module::Install::XSUtil
 
@@ -23,7 +27,7 @@ COPY ./Zonemaster-LDNS-${version}.tar.gz ./Zonemaster-LDNS-${version}.tar.gz
 RUN cpanm --notest --no-wget \
     ./Zonemaster-LDNS-${version}.tar.gz
 
-FROM alpine:3.14
+FROM alpine:3.22
 
 # Include only Zonemaster LDNS modules
 COPY --from=build /usr/local/lib/perl5/site_perl/auto/Zonemaster /usr/local/lib/perl5/site_perl/auto/Zonemaster


### PR DESCRIPTION
## Purpose

This PR fixes issues in the Dockerfile preventing images based on `develop` from being built.

## Context

Release testing for release 2025.1

## Changes

 * Bump Alpine Linux version from 3.14 (whose support has ended on 2023-05-01) to the latest version, currently 3.22.
 * Add 4 missing build-time dependencies.

## How to test this PR

Build the Docker image:
```
make all dist docker-build
```

The build process should complete successfully. Then, perform the “smoke test”:

```
docker run --rm zonemaster/ldns:local perl -MZonemaster::LDNS -E 'say Zonemaster::LDNS->new("9.9.9.9")->query("zonemaster.net")->string'
```

This command should complete with some dig-like output and no error message.