### PR TITLE
Make rr.t totally independent from network

### DIFF
--- a/t/rr.t
+++ b/t/rr.t
@@ -9,74 +9,119 @@ use Test::Differences;
 
 BEGIN { use_ok( 'Zonemaster::LDNS' ) }
 
-my $s;
-$s = Zonemaster::LDNS->new( '8.8.8.8' ) if $ENV{TEST_WITH_NETWORK};
+# The following tests use packets that are saved in a base64-encoded form. In
+# order to save a packet in Base64 while showing its presentation format, just
+# run the following script:
+#
+# $ perl -MZonemaster::LDNS -MMIME::Base64
+# my $p = Zonemaster::LDNS->new("86.54.11.100")->query("iis.se", "SOA");
+# say $p->string();
+# say encode_base64($p->wireformat());
+# ^D
 
 subtest 'rdf' => sub {
-    SKIP: {
-        skip 'no network', 1 unless $ENV{TEST_WITH_NETWORK};
+    # The packet below has the following equivalent presentation format:
+    #
+    # ;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 19192
+    # ;; flags: qr rd ra ; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+    # ;; QUESTION SECTION:
+    # ;; iis.se.      IN      SOA
+    #
+    # ;; ANSWER SECTION:
+    # iis.se. 3600    IN      SOA     nsa.dnsnowhois.stagede.net. hostmaster.nic.se. (
+    #                                 1770736690 ; serial
+    #                                 14400      ; refresh (4 hours)
+    #                                 3600       ; retry (1 hour)
+    #                                 2592000    ; expire (4 weeks 2 days)
+    #                                 480        ; minimum (8 minutes)
+    #                                 )
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(decode_base64(<<DATA));
+SviBgAABAAEAAAAAA2lpcwJzZQAABgABwAwABgABAAAOEABBA25zYQpkbnNub3dob2lzB3N0YWdl
+ZGUDbmV0AApob3N0bWFzdGVyA25pY8AQaYtMMgAAOEAAAA4QACeNAAAAAeA=
+DATA
 
-        my $p = $s->query( 'iis.se', 'SOA' );
-        plan skip_all => 'No response, cannot test' if not $p;
-
-        foreach my $rr ( $p->answer ) {
-            is( $rr->rd_count, 7 );
-            foreach my $n (0..($rr->rd_count-1)) {
-                ok(length($rr->rdf($n)) >= 4);
-            }
-            like( exception { $rr->rdf(7) }, qr/Trying to fetch nonexistent RDATA at position/, 'died on overflow');
+    foreach my $rr ( $p->answer ) {
+        is( $rr->rd_count, 7 );
+        foreach my $n (0..($rr->rd_count-1)) {
+            ok(length($rr->rdf($n)) >= 4);
         }
+        like( exception { $rr->rdf(7) }, qr/Trying to fetch nonexistent RDATA at position/, 'died on overflow');
     }
 };
 
 subtest 'SOA' => sub {
-    SKIP: {
-        skip 'no network', 1 unless $ENV{TEST_WITH_NETWORK};
+    # The packet below has the following equivalent presentation format:
+    #
+    # ;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 19192
+    # ;; flags: qr rd ra ; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+    # ;; QUESTION SECTION:
+    # ;; iis.se.      IN      SOA
+    #
+    # ;; ANSWER SECTION:
+    # iis.se. 3600    IN      SOA     nsa.dnsnowhois.stagede.net. hostmaster.nic.se. (
+    #                                 1770736690 ; serial
+    #                                 14400      ; refresh (4 hours)
+    #                                 3600       ; retry (1 hour)
+    #                                 2592000    ; expire (4 weeks 2 days)
+    #                                 480        ; minimum (8 minutes)
+    #                                 )
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(decode_base64(<<DATA));
+SviBgAABAAEAAAAAA2lpcwJzZQAABgABwAwABgABAAAOEABBA25zYQpkbnNub3dob2lzB3N0YWdl
+ZGUDbmV0AApob3N0bWFzdGVyA25pY8AQaYtMMgAAOEAAAA4QACeNAAAAAeA=
+DATA
 
-        my $p = $s->query( 'iis.se', 'SOA' );
-        plan skip_all => 'No response, cannot test' if not $p;
-
-        foreach my $rr ( $p->answer ) {
-            isa_ok( $rr, 'Zonemaster::LDNS::RR::SOA' );
-            is( lc($rr->mname), 'nsa.dnsnode.net.' );
-            is( lc($rr->rname), 'hostmaster.nic.se.' );
-            ok( $rr->serial >= 1381471502, 'serial' );
-            is( $rr->refresh, 14400,   'refresh' );
-            is( $rr->retry,   3600,    'retry' );
-            is( $rr->expire,  2592000, 'expire' );
-            is( $rr->minimum, 480,     'minimum' );
-        }
+    foreach my $rr ( $p->answer ) {
+        isa_ok( $rr, 'Zonemaster::LDNS::RR::SOA' );
+        is( lc($rr->mname), 'nsa.dnsnowhois.stagede.net.' );
+        is( lc($rr->rname), 'hostmaster.nic.se.' );
+        is( $rr->serial,  1770736690, 'serial' );
+        is( $rr->refresh, 14400,   'refresh' );
+        is( $rr->retry,   3600,    'retry' );
+        is( $rr->expire,  2592000, 'expire' );
+        is( $rr->minimum, 480,     'minimum' );
     }
 };
 
 subtest 'A' => sub {
-    SKIP: {
-        skip 'no network', 1 unless $ENV{TEST_WITH_NETWORK};
+    # The packet below has the following equivalent presentation format:
+    #
+    # ;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 10728
+    # ;; flags: qr rd ra ; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+    # ;; QUESTION SECTION:
+    # ;; a.ns.se.     IN      A
+    #
+    # ;; ANSWER SECTION:
+    # a.ns.se.        86400   IN      A       192.36.144.107
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(decode_base64(<<DATA));
+KeiBgAABAAEAAAAAAWECbnMCc2UAAAEAAcAMAAEAAQABUYAABMAkkGs
+DATA
 
-        my $p = $s->query( 'a.ns.se' );
-        plan skip_all => 'No response, cannot test' if not $p;
-
-        foreach my $rr ( $p->answer ) {
-            isa_ok( $rr, 'Zonemaster::LDNS::RR::A' );
-            is( $rr->address, '192.36.144.107', 'expected address string' );
-            is( $rr->type, 'A' );
-            is( length($rr->rdf(0)), 4 );
-        }
+    foreach my $rr ( $p->answer ) {
+        isa_ok( $rr, 'Zonemaster::LDNS::RR::A' );
+        is( $rr->address, '192.36.144.107', 'expected address string' );
+        is( $rr->type, 'A' );
+        is( length($rr->rdf(0)), 4 );
     }
 };
 
 subtest 'AAAA' => sub {
-    SKIP: {
-        skip 'no network', 1 unless $ENV{TEST_WITH_NETWORK};
+    # The packet below has the following equivalent presentation format:
+    #
+    # ;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 35420
+    # ;; flags: qr rd ra ; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+    # ;; QUESTION SECTION:
+    # ;; a.ns.se.     IN      AAAA
+    #
+    # ;; ANSWER SECTION:
+    # a.ns.se.        86400   IN      AAAA    2a01:3f0:0:301::53
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(decode_base64(<<DATA));
+ilyBgAABAAEAAAAAAWECbnMCc2UAABwAAcAMABwAAQABUYAAECoBA/AAAAMBAAAAAAAAAFM=
+DATA
 
-        my $p = $s->query( 'a.ns.se', 'AAAA' );
-        plan skip_all => 'No response, cannot test' if not $p;
-
-        foreach my $rr ( $p->answer ) {
-            isa_ok( $rr, 'Zonemaster::LDNS::RR::AAAA' );
-            is( $rr->address, '2a01:3f0:0:301::53', 'expected address string' );
-            is( length($rr->rdf(0)), 16 );
-        }
+    foreach my $rr ( $p->answer ) {
+        isa_ok( $rr, 'Zonemaster::LDNS::RR::AAAA' );
+        is( $rr->address, '2a01:3f0:0:301::53', 'expected address string' );
+        is( length($rr->rdf(0)), 16 );
     }
 };
 
@@ -173,41 +218,107 @@ subtest 'CDNSKEY' => sub {
 
 
 subtest 'RRSIG' => sub {
-    SKIP: {
-        skip 'no network', 1 unless $ENV{TEST_WITH_NETWORK};
+    # The packet below has the following equivalent presentation format.
+    # Note however that this was obtained by querying 192.36.144.107 directly
+    # instead of going through a public resolver.
+    #
+    # ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 39105
+    # ;; flags: qr aa rd; QUERY: 1, ANSWER: 6, AUTHORITY: 0, ADDITIONAL: 1
+    # ;; WARNING: recursion requested but not available
+    #
+    # ;; OPT PSEUDOSECTION:
+    # ; EDNS: version: 0, flags:; udp: 1232
+    # ;; QUESTION SECTION:
+    # ;se.                    IN RRSIG
+    #
+    # ;; ANSWER SECTION:
+    # se.                     172800 IN RRSIG SOA 8 1 172800 (
+    #                                 20260226065448 20260212052448 65293 se.
+    #                                 [omitted] )
+    # se.                     172800 IN RRSIG NS 8 1 172800 (
+    #                                 20260225210943 20260211193943 65293 se.
+    #                                 [omitted] )
+    # se.                     172800 IN RRSIG TXT 8 1 172800 (
+    #                                 20260226065448 20260212052448 65293 se.
+    #                                 [omitted] )
+    # se.                     7200 IN RRSIG NSEC 8 1 7200 (
+    #                                 20260225210943 20260211193943 65293 se.
+    #                                 [omitted] )
+    # se.                     3600 IN RRSIG DNSKEY 8 1 3600 (
+    #                                 20260225210943 20260211193943 59407 se.
+    #                                 [omitted] )
+    # se.                     172800 IN RRSIG ZONEMD 8 1 172800 (
+    #                                 20260226065448 20260212052448 65293 se.
+    #                                 [omitted] )
 
-        my $se = Zonemaster::LDNS->new( '192.36.144.107' );
-        my $pr = $se->query( 'se', 'RRSIG' );
-        plan skip_all => 'No response, cannot test' if not $pr;
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(decode_base64(<<DATA));
+mMGFAAABAAYAAAABAnNlAAAuAAHADAAuAAEAAqMAARYABggBAAKjAGmf7jhpjWQg/w0Cc2UAdvKg
+0uPsOXe/tIvyJ+EPkZhtTly2Jmp3qSN+Lc7SSYlhyse6UR9DdP4qeeJ2lx7y+iGcYqVVGFv5DZoW
+aMvUYCkd3hecFXm4GeD9i4kOcJOrkqIsK1xtP7mXMQDLPzCc1PrDNBFyV4TQWuiy0I24mBDPtJGB
+hS7Td8jQ3MXBeEe1GEZFghEEU6486+5DWa/PljTqlV5S9Q1g6T0o+2dVBnto+cUzzRwS9mGv8lNx
+heUvoeLhXDzjcqzDRkWydrifzuQyX+N0+U7wYOgQ8YVUEBd+Xwynkxjz+p2PfVCniMn7v8KEsgWy
+46/hcK0z/60UCndZNpzHixuBeTmPE0c2e8AMAC4AAQACowABFgACCAEAAqMAaZ9lF2mM2v//DQJz
+ZQCNiIePgMPpUPShOHMM8mRhhzZy722R9kVRu3+FxplHEfJcXNyR8nYj5PncyWR8VKJuherVnT71
+ARktaoXn2+0NaxR7pRZGT+eGFH0tUzrfvzGgj0ffTVfUFntnYyIB7NIsj0gJBKuzKb9OjH5BH0D8
+GPCOOBEObEtEvWJ4HL6zvHOY5Zba8Ue6KpCpGM9HUxM8hpMETvMScaAzsVu8dwnQZ0VXx7hTiRgU
+Awagn0iqWt9Ix9dyT36x7IbozjJ4fHXa5Si/s71yuPjJo/OmdBMyjtnJnMp9MCYUwH6Vnz44lBhK
+U5sDgUCg3rsolAKocp2NNPZyk7Up3E5WQo5MsFp4wAwALgABAAKjAAEWABAIAQACowBpn+44aY1k
+IP8NAnNlAAaedrKTB4N1HS/hogi47vPxqItmDiawk0eIQsSUQvGxU/JTkcBBJNuqC1px6mdCn6sR
+2RFcT1HQGOQJPUHJdoRiAdOOTDNNetal/iAnH1Y00pCmcTdKUQpME/uP6TgZJ4ex1MiwafLhdwyx
+ae9Y0JVWetb+wmHyejNjFuxtXTfRBN6hHeE2RkCyaQxFl120XXupyv9au59npUEgoAiDCTow6g+E
+fFBeZSW0ZCBVgFBwCmvB1nS0J8o9FQhYQup84MhfvGC1QMGjZsRFz4sxMF674ZQsWTDao9hbSjAM
+4GJQvUqElCZpjnp2wIeY6S9NMTWJW1jbuoepGGZwwxrPH1jADAAuAAEAABwgARYALwgBAAAcIGmf
+ZRdpjNr//w0Cc2UAga4xF7zSPOywL6eAUUbWyt5tNzO/3GWm4Yde+ASLGMBLSgsjBppvj2tvF/lL
+AnNvPqJQHDsyTnSMmEmqS0wwGgbFd0O7nwcggxIEtqFcQxuTrmroDrZgpIgU4HKoeXTRgBMXQSZ/
+keHvvyaqdVCaHImpattWFxmUlH72JIOOD9oug+6R52rXHODba+nwP50X9OXTvRPS+LvLECe1ixuS
+lKyEReJT9P6Gtjh58j+hX92YXNP0HgTHhFeJIUS8ClxWXvdbPjCMoFd1Esud30NlbkVcBygMJIh2
+qJ8u4QU4WwJKXDX25zXlLLJLrn3oweaKujfHZxu+6sZA8zXmAkaR8cAMAC4AAQAADhABFgAwCAEA
+AA4QaZ9lF2mM2v/oDwJzZQBl/ZwZxkiaoqZmJhH7SRHmu3U5eVg7OXdAVERNBepGsBIawyeFbG0k
+MD0MOFYXyQUVPzmy45IvmRQqCM4g5wWWqxJbIhrUiVjvtqOMX+BVpVHAnN1AdCGbpZpjWObK45Pc
+qDS2IYvJABqbFevkvmE31P0HdEcxuw1gykE9dsU3w5m9wBZdtA/MnRXiz6xZytYlmyOLFg05YD1Q
+DhBdq5fTpfm0ixRWjbIQyvB+ZGisHFzFE5PMXo+bccAT7+niLxymi6zrjcYP11XSMuzrdPNcdyNT
+RpfD72/Vly643EgyODcm9hZLnMIhUTtqkEKtj70ktDIIiLsYmM9iht4JOwPIwAwALgABAAKjAAEW
+AD8IAQACowBpn+44aY1kIP8NAnNlAAKbcRo5g6EVtAaxb2dpSoq5fyQgzm20vq2wwzF9Rv8I3OLJ
+XyMODTygEhOjspmyt/ZZiAYGu0ckyytu91h2Ywd7N2cTT+MYKim5YfIDaTN/7wUYn3F/haBCfAwz
+8u1j8J+/gwDnYzHUUgC2T1FROoOxm2548ix63z3PjvJoTmbTp3NOsjqr+cf1ZkokbxkiAlI0I+2K
+WGmLDwnRhXoRemWzGIxOcNu+Nc9WrY0pnJY+zk/83y9c++FQxZ7cIgQm39gANmd8pTTRNtDpYIKf
+SF/VI46p/gdy8Br7MSEvgDt1yB9IrEi8r2CshO+3xFMkvwlmtht/HRUIjEwWZ9CFB64AACkE0AAA
+AAAAAA==
+DATA
 
-        foreach my $rr ( $pr->answer ) {
-            isa_ok( $rr, 'Zonemaster::LDNS::RR::RRSIG' );
-            is( $rr->signer, 'se.' );
-            is( $rr->labels, 1 );
-            if ( $rr->typecovered eq 'DNSKEY' ) {
-                # .SE KSK should not change very often. 59407 has replaced 59747.
-                # Now (February 2022) only 59407 is used.
-                ok( $rr->keytag == 59407 );
-            }
+    foreach my $rr ( $p->answer ) {
+        isa_ok( $rr, 'Zonemaster::LDNS::RR::RRSIG' );
+        is( $rr->signer, 'se.' );
+        is( $rr->labels, 1 );
+        if ( $rr->typecovered eq 'DNSKEY' ) {
+            ok( $rr->keytag == 59407 );
         }
     }
 };
 
 subtest 'NSEC' => sub {
-    SKIP: {
-        skip 'no network', 1 unless $ENV{TEST_WITH_NETWORK};
+    # The packet below has the following equivalent presentation format.
+    # Note however that this was obtained by querying 192.36.144.107 directly
+    # instead of going through a public resolver.
+    #
+    # ;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 54748
+    # ;; flags: qr aa rd ; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+    # ;; QUESTION SECTION:
+    # ;; se.  IN      NSEC
+    #
+    # ;; ANSWER SECTION:
+    # se.     7200    IN      NSEC    0.se. NS SOA TXT RRSIG NSEC DNSKEY ZONEMD
 
-        my $se = Zonemaster::LDNS->new( '192.36.144.107' );
-        my $pn = $se->query( 'se', 'NSEC' );
-        plan skip_all => 'No response, cannot test' if not $pn;
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(decode_base64(<<DATA));
+1dyFAAABAAEAAAAAAnNlAAAvAAHADAAvAAEAABwgABABMAJzZQAACCIAgAAAA4AB
+DATA
 
-        foreach my $rr ( $pn->answer ) {
-            isa_ok( $rr, 'Zonemaster::LDNS::RR::NSEC' );
-            ok( $rr->typehref->{TXT} );
-            ok( !$rr->typehref->{MX} );
-            ok( $rr->typehref->{TXT} );
-            is( $rr->typelist, 'NS SOA TXT RRSIG NSEC DNSKEY ZONEMD ' );
-        }
+    foreach my $rr ( $p->answer ) {
+        isa_ok( $rr, 'Zonemaster::LDNS::RR::NSEC' );
+        ok( $rr->typehref->{TXT} );
+        ok( !$rr->typehref->{MX} );
+        ok( $rr->typehref->{TXT} );
+        is( $rr->typelist, 'NS SOA TXT RRSIG NSEC DNSKEY ZONEMD ' );
     }
 };
 


### PR DESCRIPTION
## Purpose

This PR changes the code in the unit test file named `t/rr.t` so as to use a crude form of saved packets, instead of relying on the network.

## Context

Resolving a CI failure when developing #241.

## Changes

* Add saved packets as Base64 blobs instead of relying on the network

## How to test this PR

Unit tests should still pass. Run both `make test` and `TEST_WITH_NETWORK=1 make test`.
