### PR TITLE
Add artifact build to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,32 @@ jobs:
       - name: test
         run: prove -bl
 
+  build-artifact:
+    needs: run-tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: apt install
+        run: sudo apt-get install -y git build-essential libmodule-install-perl libdevel-checklib-perl libextutils-pkgconfig-perl libmodule-install-xsutil-perl libssl-dev libidn2-dev
+
+      - name: build
+        run: perl Makefile.PL && make all dist
+
+      - name: Get short SHA
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+     
+      - name: Get Zonemaster-LDNS version 
+        id: version
+        run: |
+          result=`grep 'our $VERSION' lib/Zonemaster/LDNS.pm`
+          result+='printf $VERSION;'
+          VERSION=`perl -e "$result"`
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+     
+      - name: upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Zonemaster-LDNS-${{ steps.version.outputs.version }}-${{ steps.short_sha.outputs.short_sha }}
+          path: Zonemaster-LDNS-${{ steps.version.outputs.version }}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,13 @@ jobs:
 
       - name: Get short SHA
         id: short_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-     
+        run: |
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+                echo "SHORT_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_ENV
+            else
+                echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
+            fi
+
       - name: Get Zonemaster-LDNS version 
         id: version
         run: |
@@ -79,5 +84,5 @@ jobs:
       - name: upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Zonemaster-LDNS-${{ steps.version.outputs.version }}-${{ steps.short_sha.outputs.short_sha }}
+          name: Zonemaster-LDNS-${{ steps.version.outputs.version }}-${{ env.SHORT_SHA }}
           path: Zonemaster-LDNS-${{ steps.version.outputs.version }}.tar.gz

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   * [Installation from source](#installation-from-source)
   * [Post-installation sanity check](#post-installation-sanity-check)
   * [Testing](#testing)
+  * [CI artifact](#ci-artifact)
 * [Optional features](#optional-features)
   * [Ed25519]
   * [IDN]
@@ -120,6 +121,19 @@ not run). To run all tests, execute
 ```sh
 TEST_WITH_NETWORK=1 make test
 ```
+
+### CI artifact
+
+A tarball (`Zonemaster-LDNS-<version>.tar.gz`) is built and uploaded as a GitHub Actions artifact on every push and pull request. This artifact can be useful for release testing and PR review.
+
+To download it:
+
+1. Go to the [Actions tab](https://github.com/zonemaster/zonemaster-ldns/actions) of the repository.
+2. Select a workflow run (e.g. for a specific PR or branch).
+3. Scroll to the bottom of the run summary to the **Artifacts** section.
+4. Download the artifact named `Zonemaster-LDNS-<version>-<short_sha>`.
+
+The artifact name includes the module version and the first 7 characters of the commit SHA.
 
 ## Optional features
 


### PR DESCRIPTION
## Purpose

This PR adds artifact creation to CI. This artifact can be useful for release testing and PR review.
The artifact is created only if all tests pass.

## Context

Follow-up to https://github.com/zonemaster/zonemaster-backend/issues/1229

## How to test this PR

You should be able to download the artifact from the action tab and install it by following the Zonemaster documentation.
https://doc.zonemaster.fr/latest/installation/README.html
