### PR TITLE
l/Z/L/RR.pm: fix POD message about encoding.

### DIFF
--- a/lib/Zonemaster/LDNS/RR.pm
+++ b/lib/Zonemaster/LDNS/RR.pm
@@ -116,6 +116,8 @@ sub to_string {
 
 1;
 
+=encoding UTF-8
+
 =head1 NAME
 
 Zonemaster::LDNS::RR - common baseclass for all classes representing resource records.


### PR DESCRIPTION
## Purpose

Producing the Zonemaster::LDNS::RR(3pm) manual page when packaging the latest version of Zonemaster::LDNS resulted in the following POD error at the end of the manual:

	POD ERRORS
	       Hey! The above document had some coding errors, which are
	       explained below:

	       Around line 142:
	           Non-ASCII  character   seen   before   =encoding   in
	           'record’s'. Assuming UTF-8

## Changes

This change explicitly declares UTF-8 encoding at the beginning of the POD of the module.

## How to test this PR

Producing the Zonemaster::LDNS::RR(3pm) with pod2man(1) should not issue the POD error anymore.