### PR TITLE
Update LDNS to v1.9.0

### DIFF
--- a/lib/Zonemaster/LDNS/RR/CDNSKEY.pm
+++ b/lib/Zonemaster/LDNS/RR/CDNSKEY.pm
@@ -19,6 +19,4 @@ A subclass of L<Zonemaster::LDNS::RR::DNSKEY>, so it has all the methods of that
 
 No other specific methods implemented.
 
-Note that the inherited parent methods L<Zonemaster::LDNS::RR::DNSKEY/keytag()> and L<Zonemaster::LDNS::RR::DNSKEY/ds($hash)> will always return 0, as LDNS currently only supports the DNSKEY RR type for those methods.
-
 =cut

--- a/lib/Zonemaster/LDNS/RR/CDS.pm
+++ b/lib/Zonemaster/LDNS/RR/CDS.pm
@@ -19,6 +19,4 @@ A subclass of L<Zonemaster::LDNS::RR::DS>, so it has all the methods of that cla
 
 No other specific methods implemented.
 
-Note that the inherited parent methods L<Zonemaster::LDNS::RR::DS/verify($other)> will always return false, as LDNS currently only supports the DS and DNSKEY RR types for this method.
-
 =cut

--- a/lib/Zonemaster/LDNS/RRList.pm
+++ b/lib/Zonemaster/LDNS/RRList.pm
@@ -82,8 +82,6 @@ Pops an RR off the list.
 
 Returns true or false depending on if the list is an RRset or not.
 
-Note that the underlying LDNS function appears to have a bug as the comparison of the owner name field is case sensitive. See https://github.com/NLnetLabs/ldns/pull/251.
-
 =item string()
 
 Returns a string with the list of RRs in presentation format.

--- a/t/rr.t
+++ b/t/rr.t
@@ -194,8 +194,8 @@ subtest 'CDNSKEY' => sub {
         is( $rrs[0]->algorithm(),    q{8} );
         ok( $rrs[0]->keydata() );
         is( $rrs[0]->hexkeydata(),   q{BleFgAABAAEAAAAADW5sYWdyaWN1bHR1cmUCbmwAAAEAAcAMADAAAQAAAAAABAEBAwg=} );
-        is( $rrs[0]->keytag(),       q{0} );  # RR type not supported by LDNS
-        is( $rrs[0]->ds('sha256'),   undef ); # RR type not supported by LDNS
+        is( $rrs[0]->keytag(),       q{27018} );
+        is( $rrs[0]->ds('sha256'),   Zonemaster::LDNS::RR->new(q{cdnskey.test. 0 IN DS 27018 8 2 11144150cb6c0690613d6cca962c3939de03a41cdac0787aae59db93b0ae8530} ));
         is( $rrs[0]->keysize(),      q{344} );
     };
 


### PR DESCRIPTION
## Purpose

This PR updates LDNS to v1.9.0


## Context
Fixes #252 

## Changes

`keytag()` and `ds()` function are now working for CDNSKEY.

## How to test this PR

Test and CI must work.
