### PR TITLE
Add support for Extended DNS Errors (EDEs)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -185,6 +185,7 @@ src/LDNS.xs
 src/typemap
 t/axfr.t
 t/dnssec.t
+t/ede.t
 t/example.org
 t/idn.t
 t/load_zonefile.t

--- a/lib/Zonemaster/LDNS/Packet.pm
+++ b/lib/Zonemaster/LDNS/Packet.pm
@@ -103,6 +103,16 @@ sub additional_rrlist {
     return Zonemaster::LDNS::RRList->new( \@records );
 }
 
+sub ede {
+    my $self = shift @_;
+    if ( scalar @_ > 0 ) {
+        return $self->_set_ede(@_);
+    }
+    else {
+        return $self->_get_ede();
+    }
+}
+
 1;
 
 =head1 NAME
@@ -309,5 +319,13 @@ Returns a Perl string holding the packet in wire format.
 =item type()
 
 Returns the ldns library's guess as to the content of the packet. One of the strings C<question>, C<referral>, C<answer>, C<nxdomain>, C<nodata> or C<unknown>.
+
+=item ede( [ $error_code, [ $extra_text ] ] )
+
+Gets or sets the first Extended DNS Error (EDE) in the packet.
+
+In scalar context, returns the EDE code, or C<undef> if there is none.
+
+In list context, returns both the EDE code (or C<undef> if there is no EDE), and the extra text (or C<undef> if there is no EDE or if the EDE has no extra text).
 
 =back

--- a/lib/Zonemaster/LDNS/Packet.pm
+++ b/lib/Zonemaster/LDNS/Packet.pm
@@ -192,7 +192,7 @@ Gets and/or sets the EDNS0 UDP size.
 
 Gets and/or sets the EDNS0 Extended RCODE field.
 
-=item ends_z()
+=item edns_z()
 
 Gets and/or sets the EDNS0 Z bits.
 

--- a/lib/Zonemaster/LDNS/Packet.pm
+++ b/lib/Zonemaster/LDNS/Packet.pm
@@ -104,9 +104,18 @@ sub additional_rrlist {
 }
 
 sub first_ede {
-    my $self = shift @_;
-    if ( scalar @_ > 0 ) {
-        return $self->_set_first_ede(@_);
+    my ( $self, @args ) = @_;
+    if ( scalar @args > 0 ) {
+        my ( $ede, $text ) = @args;
+
+        # Encode string into UTF-8 byte sequence if not already done so
+        if ( defined $text and utf8::is_utf8( $text ) ) {
+            $text = Encode::encode( 'UTF-8', $text );
+            return $self->_set_first_ede( $ede, $text );
+        }
+        else {
+            return $self->_set_first_ede( @args );
+        }
     }
     else {
         return $self->_get_first_ede();

--- a/lib/Zonemaster/LDNS/Packet.pm
+++ b/lib/Zonemaster/LDNS/Packet.pm
@@ -103,13 +103,13 @@ sub additional_rrlist {
     return Zonemaster::LDNS::RRList->new( \@records );
 }
 
-sub ede {
+sub first_ede {
     my $self = shift @_;
     if ( scalar @_ > 0 ) {
-        return $self->_set_ede(@_);
+        return $self->_set_first_ede(@_);
     }
     else {
-        return $self->_get_ede();
+        return $self->_get_first_ede();
     }
 }
 
@@ -322,7 +322,7 @@ Returns a Perl string holding the packet in wire format.
 
 Returns the ldns library's guess as to the content of the packet. One of the strings C<question>, C<referral>, C<answer>, C<nxdomain>, C<nodata> or C<unknown>.
 
-=item ede( [ $error_code, [ $extra_text ] ] )
+=item first_ede( [ $error_code, [ $extra_text ] ] )
 
 Gets (if called without any arguments) or sets (if called with one or two
 arguments) the first Extended DNS Error (EDE) in the packet.

--- a/lib/Zonemaster/LDNS/Packet.pm
+++ b/lib/Zonemaster/LDNS/Packet.pm
@@ -103,7 +103,19 @@ sub additional_rrlist {
     return Zonemaster::LDNS::RRList->new( \@records );
 }
 
+sub ede {
+    my $self = shift @_;
+    if ( scalar @_ > 0 ) {
+        return $self->_set_ede(@_);
+    }
+    else {
+        return $self->_get_ede();
+    }
+}
+
 1;
+
+=encoding UTF-8
 
 =head1 NAME
 
@@ -309,5 +321,47 @@ Returns a Perl string holding the packet in wire format.
 =item type()
 
 Returns the ldns library's guess as to the content of the packet. One of the strings C<question>, C<referral>, C<answer>, C<nxdomain>, C<nodata> or C<unknown>.
+
+=item ede( [ $error_code, [ $extra_text ] ] )
+
+Gets (if called without any arguments) or sets (if called with one or two
+arguments) the first Extended DNS Error (EDE) in the packet.
+
+As a setter, always returns C<undef>.
+
+As a getter, the return value depends on the context.
+
+In scalar context, returns the value of the EDE INFO-CODE field, or C<undef>
+if the packet contains no EDE.
+
+In list context, returns:
+
+=over
+
+=item *
+
+an empty list if there is no EDE;
+
+=item *
+
+a list of one item, the EDE INFO-CODE, if there is an EDE without EXTRA-TEXT;
+
+=item *
+
+a list of two items, the EDE INFO-CODE and the EXTRA-TEXT, if there is an EDE with EXTRA-TEXT.
+
+=back
+
+This list can be unpacked into a pair of variables, like this:
+
+    my ( $code, $extra_text ) = $packet->first_ede();
+
+The EDE EXTRA-TEXT is specified in RFC 8914 to be UTF-8 encoded text. When
+retrieving the EXTRA-TEXT from a packet, UTF-8 valid text is returned as a
+Unicode character string, and UTF-8 invalid text, although forbidden, is
+returned as a (binary) byte string. Trailing NUL bytes are preserved both when
+setting the EXTRA-TEXT in a packet or when getting a packet’s EXTRA-TEXT.
+
+
 
 =back

--- a/lib/Zonemaster/LDNS/Packet.pm
+++ b/lib/Zonemaster/LDNS/Packet.pm
@@ -194,7 +194,7 @@ Gets and/or sets the EDNS0 UDP size.
 
 Gets and/or sets the EDNS0 Extended RCODE field.
 
-=item ends_z()
+=item edns_z()
 
 Gets and/or sets the EDNS0 Z bits.
 

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1498,6 +1498,106 @@ packet_type(obj)
     OUTPUT:
         RETVAL
 
+
+void
+packet__get_ede(obj)
+    Zonemaster::LDNS::Packet obj;
+    INIT:
+        ldns_edns_option_list *edns_opts;
+        ldns_edns_option *option;
+        size_t i;
+        size_t opts_count;
+        uint16_t ede_code = 0;
+        char *ede_text = NULL;
+        U8 gimme = GIMME_V;
+        SV *sv;
+
+    PPCODE:
+        if (gimme == G_VOID) {
+            XSRETURN_UNDEF;
+        }
+
+        edns_opts = ldns_pkt_edns_get_option_list(obj);
+        if (edns_opts == NULL) {
+            XSRETURN_UNDEF;
+        }
+
+        opts_count = ldns_edns_option_list_get_count(edns_opts);
+        for (i = 0; i < opts_count; i++) {
+            option = ldns_edns_option_list_get_option(edns_opts, i);
+            if (option != NULL &&
+                  ldns_edns_get_code(option) == LDNS_EDNS_EDE &&
+                  ldns_edns_ede_get_code(option, &ede_code) == LDNS_STATUS_OK) {
+                break;
+            }
+        }
+
+        if (i == opts_count) {
+            XSRETURN_UNDEF;
+        }
+
+        mXPUSHu(ede_code);
+
+        if (gimme == G_ARRAY &&
+              ldns_edns_ede_get_text(option, &ede_text) == LDNS_STATUS_OK &&
+              ede_text != NULL) {
+            sv = newSVpvn(ede_text, ldns_edns_get_size(option) - 2);
+            sv_utf8_decode(sv);
+            mXPUSHs(sv);
+            free(ede_text);
+        }
+
+void
+packet__set_ede(obj, ede, ...)
+    Zonemaster::LDNS::Packet obj;
+    U16 ede;
+    INIT:
+        ldns_edns_option_list *edns_opts;
+        ldns_edns_option *option;
+        ldns_edns_option *new_option;
+        size_t i;
+        size_t opts_count;
+        STRLEN len;
+        uint8_t *buf;
+        char *extra_text;
+
+    PPCODE:
+        edns_opts = ldns_pkt_edns_get_option_list(obj);
+        if (edns_opts == NULL) {
+            edns_opts = ldns_edns_option_list_new();
+            ldns_pkt_set_edns_option_list(obj, edns_opts);
+        }
+
+        opts_count = ldns_edns_option_list_get_count(edns_opts);
+        for (i = 0; i < opts_count; i++) {
+            option = ldns_edns_option_list_get_option(edns_opts, i);
+            if (option != NULL && ldns_edns_get_code(option) == LDNS_EDNS_EDE) {
+                break;
+            }
+        }
+
+        if (items > 2) {
+            extra_text = SvPVutf8(ST(2), len);
+            len += sizeof(uint16_t);
+            buf = malloc(len);
+            memcpy(buf + sizeof(uint16_t), extra_text, len - sizeof(uint16_t));
+        }
+        else {
+            len = sizeof(uint16_t);
+            buf = malloc(len);
+        }
+        *((uint16_t*)buf) = htons(ede);
+
+        new_option = ldns_edns_new(LDNS_EDNS_EDE, len, buf);
+
+        if (i < opts_count) {
+            ldns_edns_option_list_set_option(edns_opts, new_option, i);
+        }
+        else {
+            ldns_edns_option_list_push(edns_opts, new_option);
+        }
+
+
 void
 packet_DESTROY(sv)
     SV *sv;

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1500,7 +1500,7 @@ packet_type(obj)
 
 
 void
-packet__get_ede(obj)
+packet__get_first_ede(obj)
     Zonemaster::LDNS::Packet obj;
     INIT:
         ldns_edns_option_list *edns_opts;
@@ -1548,7 +1548,7 @@ packet__get_ede(obj)
         }
 
 void
-packet__set_ede(obj, ede, ...)
+packet__set_first_ede(obj, ede, ...)
     Zonemaster::LDNS::Packet obj;
     U16 ede;
     INIT:

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1579,8 +1579,8 @@ packet__set_first_ede(obj, ede, ...)
             }
         }
 
-        if (items > 2) {
-            extra_text = SvPVutf8(ST(2), len);
+        if (items > 2 && SvOK(ST(2))) {
+            extra_text = SvPV(ST(2), len);
             len += sizeof(uint16_t);
             buf = malloc(len);
             memcpy(buf + sizeof(uint16_t), extra_text, len - sizeof(uint16_t));

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -1498,6 +1498,112 @@ packet_type(obj)
     OUTPUT:
         RETVAL
 
+
+void
+packet__get_ede(obj)
+    Zonemaster::LDNS::Packet obj;
+    INIT:
+        ldns_edns_option_list *edns_opts;
+        ldns_edns_option *option;
+        size_t i;
+        size_t opts_count;
+        uint16_t ede_code = 0;
+        char *ede_text = NULL;
+        U8 gimme = GIMME_V;
+        SV *sv;
+
+    PPCODE:
+        if (gimme == G_VOID) {
+            XSRETURN_UNDEF;
+        }
+
+        edns_opts = ldns_pkt_edns_get_option_list(obj);
+        if (edns_opts == NULL) {
+            XSRETURN_UNDEF;
+        }
+
+        opts_count = ldns_edns_option_list_get_count(edns_opts);
+        for (i = 0; i < opts_count; i++) {
+            option = ldns_edns_option_list_get_option(edns_opts, i);
+            if (option != NULL &&
+                  ldns_edns_get_code(option) == LDNS_EDNS_EDE &&
+                  ldns_edns_ede_get_code(option, &ede_code) == LDNS_STATUS_OK) {
+                break;
+            }
+        }
+
+        if (i == opts_count) {
+            XSRETURN_UNDEF;
+        }
+
+        mXPUSHu(ede_code);
+
+        if (gimme == G_ARRAY &&
+              ldns_edns_ede_get_text(option, &ede_text) == LDNS_STATUS_OK &&
+              ede_text != NULL) {
+            sv = newSVpvn(ede_text, ldns_edns_get_size(option) - 2);
+            sv_utf8_decode(sv);
+            mXPUSHs(sv);
+            free(ede_text);
+        }
+
+void
+packet__set_ede(obj, ede, ...)
+    Zonemaster::LDNS::Packet obj;
+    U16 ede;
+    INIT:
+        ldns_edns_option_list *edns_opts;
+        ldns_edns_option *option;
+        ldns_edns_option *new_option;
+        size_t i;
+        size_t opts_count;
+        STRLEN len;
+        uint8_t *buf;
+        char *extra_text;
+
+    PPCODE:
+        edns_opts = ldns_pkt_edns_get_option_list(obj);
+        if (edns_opts == NULL) {
+            edns_opts = ldns_edns_option_list_new();
+            if (edns_opts == NULL) {
+                croak("Could not allocate EDNS option list");
+            }
+            ldns_pkt_set_edns_option_list(obj, edns_opts);
+        }
+
+        opts_count = ldns_edns_option_list_get_count(edns_opts);
+        for (i = 0; i < opts_count; i++) {
+            option = ldns_edns_option_list_get_option(edns_opts, i);
+            if (option != NULL && ldns_edns_get_code(option) == LDNS_EDNS_EDE) {
+                break;
+            }
+        }
+
+        if (items > 2) {
+            extra_text = SvPVutf8(ST(2), len);
+            len += sizeof(uint16_t);
+            buf = malloc(len);
+            memcpy(buf + sizeof(uint16_t), extra_text, len - sizeof(uint16_t));
+        }
+        else {
+            len = sizeof(uint16_t);
+            buf = malloc(len);
+        }
+        *((uint16_t*)buf) = htons(ede);
+
+        new_option = ldns_edns_new(LDNS_EDNS_EDE, len, buf);
+
+        if (i < opts_count) {
+            option = ldns_edns_option_list_set_option(edns_opts, new_option, i);
+            if (option != NULL) {
+                ldns_edns_deep_free(option);
+            }
+        }
+        else {
+            ldns_edns_option_list_push(edns_opts, new_option);
+        }
+
+
 void
 packet_DESTROY(sv)
     SV *sv;

--- a/t/ede.t
+++ b/t/ede.t
@@ -1,0 +1,251 @@
+use strict;
+use warnings;
+use v5.16;
+
+use utf8;
+
+use open ':std', ':encoding(UTF-8)';
+use Test::More;
+use Test::Fatal qw(exception lives_ok);
+use MIME::Base64;
+use Test::Differences;
+
+BEGIN { use_ok( 'Zonemaster::LDNS' ) }
+
+sub test_ede {
+    my ( $packet, $expected_ede, $expected_extra_text ) = @_;
+
+    my $expected_ede_message = (defined $expected_ede) ? 
+        'Got expected EDE' : 'Got no EDE';
+    my $expected_ede_text_message = (defined $expected_extra_text) ? 
+        'Got expected extra text' : 'Got no extra text';
+
+    {
+        my $ede;
+        is(
+            exception { $ede = $packet->ede() },
+            undef,
+            'ede() method works in scalar context'
+        );
+        is( $ede, $expected_ede, $expected_ede_message );
+    }
+    {
+        my ( $ede, $extra_text );
+        is(
+            exception { ( $ede, $extra_text ) = $packet->ede() },
+            undef,
+            'ede() method works in list context'
+        );
+        is( $ede, $expected_ede, $expected_ede_message );
+        is( $extra_text, $expected_extra_text, $expected_ede_text_message );
+    }
+}
+
+#
+# This test packet was obtained by performing the following query:
+#
+# % dig @ns1.ede-13.extended-dns-errors.com TXT ede-13.extended-dns-errors.com.
+#
+# It contains an EDE 13 (Cached Error) with the extra text “This EDE was
+# intentionally inserted by dnsdist”.
+#
+subtest 'Packet with EDE + ASCII text' => sub {
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(decode_base64(<<DATA));
+jCGFAAABAAAAAQABBmVkZS0xMxNleHRlbmRlZC1kbnMtZXJyb3JzA2NvbQAAEAABwAwABgABAAACWA
+AnA25zMcAMCmhvc3RtYXN0ZXLADAE1ALUAAFRgAAAOEAAJOoAAAVGAAAApBNAAAAAAAFAACgAY2Jns
+Gd/Ahl4BAAAAac0D6x4N9CxTQ07sAA8AMAANVGhpcyBFREUgd2FzIGludGVudGlvbmFsbHkgaW5zZX
+J0ZWQgYnkgZG5zZGlzdA==
+DATA
+
+    test_ede( $p, 13, 'This EDE was intentionally inserted by dnsdist' );
+};
+
+#
+# This test packet was obtained by performing the following query:
+#
+# % dig @a.ede.dn5.dk AAAA network-error.nx.ede.dn5.dk
+#
+# It contains an EDE 13 (Cached Error) with the extra text “🔥🔥🔥”.
+#
+subtest 'Packet with EDE + UTF-8 text' => sub {
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(decode_base64(<<DATA));
+6D+FAwABAAAAAAABDW5ldHdvcmstZXJyb3ICbngDZWRlA2RuNQJkawAAHAABAAApBNAAAAAAABIADw
+AOABfwn5Sl8J+UpfCflKU=
+DATA
+
+    test_ede( $p, 23, '🔥🔥🔥' );
+};
+
+#
+# This test packet was obtained by performing the following query:
+#
+# % dig +nord +nocookie @aphrodite.x0r.fr SOA blah.
+#
+# It contains an EDE 20 (Not Authoritative) with no extra text.
+#
+
+subtest 'Test packet with plain EDE' => sub {
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(decode_base64(<<DATA));
+s5yABQABAAAAAAABBGJsYWgAAAYAAQAAKRAAAAAAAAAGAA8AAgAU
+DATA
+
+    test_ede( $p, 20, undef );
+};
+
+#
+# Test setting an EDE in an existing packet.
+#
+
+subtest 'setting plain EDE in packet' => sub {
+    my $p = Zonemaster::LDNS::Packet->new( 'test' );
+    $p->qr(1);
+    $p->aa(1);
+    $p->opcode('QUERY');
+    $p->rcode('REFUSED');
+
+    test_ede( $p, undef, undef );
+
+    is(
+        exception { $p->ede(1) },
+        undef,
+        'Setting plain EDE doesn’t crash'
+    );
+    test_ede( $p, 1, undef );
+
+    my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
+000084050001000000000001     # Header
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 0006   # Additional section: OPT pseudo-RR
+000f 0002 0001               # EDNS option 15 (EDE), length and code 1
+DATA
+
+    is(
+        unpack( 'H*', $p->wireformat() ),
+        $expected_wireformat,
+        'Packet contains only one instance of EDE'
+    );
+};
+
+subtest 'setting EDE multiple times only keeps one instance of EDE' => sub {
+    my $p = Zonemaster::LDNS::Packet->new( 'test' );
+    $p->qr(1);
+    $p->aa(1);
+    $p->opcode('QUERY');
+    $p->rcode('REFUSED');
+
+    is(
+        exception { $p->ede($_) for 1..4 },
+        undef,
+        'Setting plain EDE 4 times in a row doesn’t crash'
+    );
+    test_ede( $p, 4, undef );
+
+    my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
+000084050001000000000001     # Header
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 0006   # Additional section: OPT pseudo-RR
+000f 0002 0004               # EDNS option 15 (EDE), length and code 4
+DATA
+
+    is(
+        unpack( 'H*', $p->wireformat() ),
+        $expected_wireformat,
+        'Packet contains only one instance of EDE'
+    );
+};
+
+subtest 'setting EDE with extra text' => sub {
+    my $p = Zonemaster::LDNS::Packet->new( 'test' );
+    $p->qr(1);
+    $p->aa(1);
+    $p->opcode('QUERY');
+    $p->rcode('REFUSED');
+
+    is(
+        exception { $p->ede(13, 'AXFR failed: REFUSED') },
+        undef,
+        'Setting EDE with text doesn’t crash'
+    );
+    test_ede( $p, 13, 'AXFR failed: REFUSED' );
+
+    my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
+000084050001000000000001     # Header
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 001a   # Additional section: OPT pseudo-RR
+000f 0016                    # EDNS option 15 (EDE) and length
+000d 41584652206661696c65643a2052454655534544  # EDE code 13 and text
+DATA
+
+    is(
+        unpack( 'H*', $p->wireformat() ),
+        $expected_wireformat,
+        'Packet contains only one instance of EDE'
+    );
+};
+
+subtest 'setting EDE with UTF-8 text' => sub {
+    my $p = Zonemaster::LDNS::Packet->new( 'test' );
+    $p->qr(1);
+    $p->aa(1);
+    $p->opcode('QUERY');
+    $p->rcode('REFUSED');
+
+    my $backup = '🐈';
+    my $extra_text = '🐈';
+
+    is(
+        exception { $p->ede(29, $extra_text) },
+        undef,
+        'Setting EDE with UTF-8 text doesn’t crash'
+    );
+    test_ede( $p, 29, $backup );
+
+    is( $extra_text, $backup, 'Setting EDE has no ill side-effects on input variable' );
+
+    my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
+000084050001000000000001     # Header
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 000a   # Additional section: OPT pseudo-RR
+000f 0006                    # EDNS option 15 (EDE) and length
+001d f09f9088                # EDE code 29 and cat emoji (U+1F408)
+DATA
+
+    is(
+        unpack( 'H*', $p->wireformat() ),
+        $expected_wireformat,
+        'Packet contains only one instance of EDE'
+    );
+};
+
+subtest 'setting EDE with null bytes in it' => sub {
+    my $p = Zonemaster::LDNS::Packet->new( 'test' );
+    $p->qr(1);
+    $p->aa(1);
+    $p->opcode('QUERY');
+    $p->rcode('REFUSED');
+
+    my $extra_text = "Messing\0with\0you\0";
+
+    is(
+        exception { $p->ede(65530, $extra_text) },
+        undef,
+        'Setting EDE with embedded null bytes doesn’t crash'
+    );
+    test_ede( $p, 65530, $extra_text );
+
+    my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
+000084050001000000000001     # Header
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 0017   # Additional section: OPT pseudo-RR
+000f 0013                    # EDNS option 15 (EDE) and length
+fffa 4d657373696e67 00 77697468 00 796f75 00 # EDE code and string
+DATA
+
+    is(
+        unpack( 'H*', $p->wireformat() ),
+        $expected_wireformat,
+        'Packet’s wireformat is correct'
+    );
+};
+
+done_testing;

--- a/t/ede.t
+++ b/t/ede.t
@@ -1,0 +1,272 @@
+use strict;
+use warnings;
+use v5.16;
+
+use utf8;
+
+use open ':std', ':encoding(UTF-8)';
+use Test::More;
+use Test::Fatal qw(exception lives_ok);
+use MIME::Base64;
+use Test::Differences;
+
+BEGIN { use_ok( 'Zonemaster::LDNS' ) }
+
+sub test_ede {
+    my ( $packet, $expected_ede, $expected_extra_text ) = @_;
+
+    my $expected_ede_message = (defined $expected_ede) ? 
+        'Got expected EDE' : 'Got no EDE';
+    my $expected_ede_text_message = (defined $expected_extra_text) ? 
+        'Got expected extra text' : 'Got no extra text';
+
+    {
+        my $ede;
+        is(
+            exception { $ede = $packet->ede() },
+            undef,
+            'ede() method works in scalar context'
+        );
+        is( $ede, $expected_ede, $expected_ede_message );
+    }
+    {
+        my ( $ede, $extra_text );
+        is(
+            exception { ( $ede, $extra_text ) = $packet->ede() },
+            undef,
+            'ede() method works in list context'
+        );
+        is( $ede, $expected_ede, $expected_ede_message );
+        is( $extra_text, $expected_extra_text, $expected_ede_text_message );
+    }
+}
+
+#
+# This test packet was obtained by performing the following query:
+#
+# % dig @ns1.ede-13.extended-dns-errors.com TXT ede-13.extended-dns-errors.com.
+#
+# It contains an EDE 13 (Cached Error) with the extra text “This EDE was
+# intentionally inserted by dnsdist”.
+#
+subtest 'Packet with EDE + ASCII text' => sub {
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(decode_base64(<<DATA));
+jCGFAAABAAAAAQABBmVkZS0xMxNleHRlbmRlZC1kbnMtZXJyb3JzA2NvbQAAEAABwAwABgABAAACWA
+AnA25zMcAMCmhvc3RtYXN0ZXLADAE1ALUAAFRgAAAOEAAJOoAAAVGAAAApBNAAAAAAAFAACgAY2Jns
+Gd/Ahl4BAAAAac0D6x4N9CxTQ07sAA8AMAANVGhpcyBFREUgd2FzIGludGVudGlvbmFsbHkgaW5zZX
+J0ZWQgYnkgZG5zZGlzdA==
+DATA
+
+    test_ede( $p, 13, 'This EDE was intentionally inserted by dnsdist' );
+};
+
+#
+# This test packet was obtained by performing the following query:
+#
+# % dig @a.ede.dn5.dk AAAA network-error.nx.ede.dn5.dk
+#
+# It contains an EDE 13 (Cached Error) with the extra text “🔥🔥🔥”.
+#
+subtest 'Packet with EDE + UTF-8 text' => sub {
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(decode_base64(<<DATA));
+6D+FAwABAAAAAAABDW5ldHdvcmstZXJyb3ICbngDZWRlA2RuNQJkawAAHAABAAApBNAAAAAAABIADw
+AOABfwn5Sl8J+UpfCflKU=
+DATA
+
+    test_ede( $p, 23, '🔥🔥🔥' );
+};
+
+#
+# This is a synthetic test packet.
+#
+# It contains an EDE 0 (Other) with some extra text which is not
+# a valid UTF-8 sequence.
+#
+# Although RFC 8914 specifies that the EXTRA-TEXT be UTF-8-encoded,
+# we should accept byte sequences that are invalid.
+#
+subtest 'Packet with EDE + invalid UTF-8 text' => sub {
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(
+        pack( 'H*', (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx) ) );
+000084020001000000000001     # Header: QR AA, SERVFAIL
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 000e   # Additional section: OPT pseudo-RR
+000f 000a 0000               # EDNS option 15 (EDE), length and code 0
+48 65 6c 70 aa 6d 65 bb      # Extra text
+DATA
+    test_ede( $p, 0, "Help\xAAme\xBB" );
+};
+
+#
+# This test packet was obtained by performing the following query:
+#
+# % dig +nord +nocookie @aphrodite.x0r.fr SOA blah.
+#
+# It contains an EDE 20 (Not Authoritative) with no extra text.
+#
+
+subtest 'Test packet with plain EDE' => sub {
+    my $p = Zonemaster::LDNS::Packet->new_from_wireformat(decode_base64(<<DATA));
+s5yABQABAAAAAAABBGJsYWgAAAYAAQAAKRAAAAAAAAAGAA8AAgAU
+DATA
+
+    test_ede( $p, 20, undef );
+};
+
+#
+# Test setting an EDE in an existing packet.
+#
+
+subtest 'setting plain EDE in packet' => sub {
+    my $p = Zonemaster::LDNS::Packet->new( 'test' );
+    $p->qr(1);
+    $p->aa(1);
+    $p->opcode('QUERY');
+    $p->rcode('REFUSED');
+
+    test_ede( $p, undef, undef );
+
+    is(
+        exception { $p->ede(1) },
+        undef,
+        'Setting plain EDE doesn’t crash'
+    );
+    test_ede( $p, 1, undef );
+
+    my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
+000084050001000000000001     # Header
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 0006   # Additional section: OPT pseudo-RR
+000f 0002 0001               # EDNS option 15 (EDE), length and code 1
+DATA
+
+    is(
+        unpack( 'H*', $p->wireformat() ),
+        $expected_wireformat,
+        'Packet contains only one instance of EDE'
+    );
+};
+
+subtest 'setting EDE multiple times only keeps one instance of EDE' => sub {
+    my $p = Zonemaster::LDNS::Packet->new( 'test' );
+    $p->qr(1);
+    $p->aa(1);
+    $p->opcode('QUERY');
+    $p->rcode('REFUSED');
+
+    is(
+        exception { $p->ede($_) for 1..4 },
+        undef,
+        'Setting plain EDE 4 times in a row doesn’t crash'
+    );
+    test_ede( $p, 4, undef );
+
+    my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
+000084050001000000000001     # Header
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 0006   # Additional section: OPT pseudo-RR
+000f 0002 0004               # EDNS option 15 (EDE), length and code 4
+DATA
+
+    is(
+        unpack( 'H*', $p->wireformat() ),
+        $expected_wireformat,
+        'Packet contains only one instance of EDE'
+    );
+};
+
+subtest 'setting EDE with extra text' => sub {
+    my $p = Zonemaster::LDNS::Packet->new( 'test' );
+    $p->qr(1);
+    $p->aa(1);
+    $p->opcode('QUERY');
+    $p->rcode('REFUSED');
+
+    is(
+        exception { $p->ede(13, 'AXFR failed: REFUSED') },
+        undef,
+        'Setting EDE with text doesn’t crash'
+    );
+    test_ede( $p, 13, 'AXFR failed: REFUSED' );
+
+    my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
+000084050001000000000001     # Header
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 001a   # Additional section: OPT pseudo-RR
+000f 0016                    # EDNS option 15 (EDE) and length
+000d 41584652206661696c65643a2052454655534544  # EDE code 13 and text
+DATA
+
+    is(
+        unpack( 'H*', $p->wireformat() ),
+        $expected_wireformat,
+        'Packet contains only one instance of EDE'
+    );
+};
+
+subtest 'setting EDE with UTF-8 text' => sub {
+    my $p = Zonemaster::LDNS::Packet->new( 'test' );
+    $p->qr(1);
+    $p->aa(1);
+    $p->opcode('QUERY');
+    $p->rcode('REFUSED');
+
+    my $backup = '🐈';
+    my $extra_text = '🐈';
+
+    is(
+        exception { $p->ede(29, $extra_text) },
+        undef,
+        'Setting EDE with UTF-8 text doesn’t crash'
+    );
+    test_ede( $p, 29, $backup );
+
+    is( $extra_text, $backup, 'Setting EDE has no ill side-effects on input variable' );
+
+    my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
+000084050001000000000001     # Header
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 000a   # Additional section: OPT pseudo-RR
+000f 0006                    # EDNS option 15 (EDE) and length
+001d f09f9088                # EDE code 29 and cat emoji (U+1F408)
+DATA
+
+    is(
+        unpack( 'H*', $p->wireformat() ),
+        $expected_wireformat,
+        'Packet contains only one instance of EDE'
+    );
+};
+
+subtest 'setting EDE with null bytes in it' => sub {
+    my $p = Zonemaster::LDNS::Packet->new( 'test' );
+    $p->qr(1);
+    $p->aa(1);
+    $p->opcode('QUERY');
+    $p->rcode('REFUSED');
+
+    my $extra_text = "Messing\0with\0you\0";
+
+    is(
+        exception { $p->ede(65530, $extra_text) },
+        undef,
+        'Setting EDE with embedded null bytes doesn’t crash'
+    );
+    test_ede( $p, 65530, $extra_text );
+
+    my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
+000084050001000000000001     # Header
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 0017   # Additional section: OPT pseudo-RR
+000f 0013                    # EDNS option 15 (EDE) and length
+fffa 4d657373696e67 00 77697468 00 796f75 00 # EDE code and string
+DATA
+
+    is(
+        unpack( 'H*', $p->wireformat() ),
+        $expected_wireformat,
+        'Packet’s wireformat is correct'
+    );
+};
+
+done_testing;

--- a/t/ede.t
+++ b/t/ede.t
@@ -30,12 +30,20 @@ sub test_ede {
         is( $ede, $expected_ede, $expected_ede_message );
     }
     {
-        my ( $ede, $extra_text );
+        my @array;
         is(
-            exception { ( $ede, $extra_text ) = $packet->ede() },
+            exception {
+                @array = $packet->ede();
+            },
             undef,
             'ede() method works in list context'
         );
+        # In some scenarios, list context calls can return 0 or 1 item. This
+        # is acceptable because missing values in the code that unpacks the
+        # following array become undef. As long as we don’t return more than
+        # two, it’s fine.
+        cmp_ok( scalar @array, '<=', 2 );
+        my ( $ede, $extra_text ) = @array;
         is( $ede, $expected_ede, $expected_ede_message );
         is( $extra_text, $expected_extra_text, $expected_ede_text_message );
     }

--- a/t/ede.t
+++ b/t/ede.t
@@ -12,31 +12,29 @@ use Test::Differences;
 
 BEGIN { use_ok( 'Zonemaster::LDNS' ) }
 
-sub test_ede {
+sub test_first_ede {
     my ( $packet, $expected_ede, $expected_extra_text ) = @_;
 
-    my $expected_ede_message = (defined $expected_ede) ? 
+    my $expected_ede_message = (defined $expected_ede) ?
         'Got expected EDE' : 'Got no EDE';
-    my $expected_ede_text_message = (defined $expected_extra_text) ? 
+    my $expected_ede_text_message = (defined $expected_extra_text) ?
         'Got expected extra text' : 'Got no extra text';
 
     {
         my $ede;
         is(
-            exception { $ede = $packet->ede() },
+            exception { $ede = $packet->first_ede() },
             undef,
-            'ede() method works in scalar context'
+            'first_ede() method works in scalar context'
         );
         is( $ede, $expected_ede, $expected_ede_message );
     }
     {
         my @array;
         is(
-            exception {
-                @array = $packet->ede();
-            },
+            exception { @array = $packet->first_ede() },
             undef,
-            'ede() method works in list context'
+            'first_ede() method works in list context'
         );
         # In some scenarios, list context calls can return 0 or 1 item. This
         # is acceptable because missing values in the code that unpacks the
@@ -65,7 +63,7 @@ Gd/Ahl4BAAAAac0D6x4N9CxTQ07sAA8AMAANVGhpcyBFREUgd2FzIGludGVudGlvbmFsbHkgaW5zZX
 J0ZWQgYnkgZG5zZGlzdA==
 DATA
 
-    test_ede( $p, 13, 'This EDE was intentionally inserted by dnsdist' );
+    test_first_ede( $p, 13, 'This EDE was intentionally inserted by dnsdist' );
 };
 
 #
@@ -81,7 +79,7 @@ subtest 'Packet with EDE + UTF-8 text' => sub {
 AOABfwn5Sl8J+UpfCflKU=
 DATA
 
-    test_ede( $p, 23, '🔥🔥🔥' );
+    test_first_ede( $p, 23, '🔥🔥🔥' );
 };
 
 #
@@ -102,7 +100,7 @@ subtest 'Packet with EDE + invalid UTF-8 text' => sub {
 000f 000a 0000               # EDNS option 15 (EDE), length and code 0
 48 65 6c 70 aa 6d 65 bb      # Extra text
 DATA
-    test_ede( $p, 0, "Help\xAAme\xBB" );
+    test_first_ede( $p, 0, "Help\xAAme\xBB" );
 };
 
 #
@@ -118,7 +116,7 @@ subtest 'Test packet with plain EDE' => sub {
 s5yABQABAAAAAAABBGJsYWgAAAYAAQAAKRAAAAAAAAAGAA8AAgAU
 DATA
 
-    test_ede( $p, 20, undef );
+    test_first_ede( $p, 20, undef );
 };
 
 #
@@ -132,14 +130,14 @@ subtest 'setting plain EDE in packet' => sub {
     $p->opcode('QUERY');
     $p->rcode('REFUSED');
 
-    test_ede( $p, undef, undef );
+    test_first_ede( $p, undef, undef );
 
     is(
-        exception { $p->ede(1) },
+        exception { $p->first_ede(1) },
         undef,
         'Setting plain EDE doesn’t crash'
     );
-    test_ede( $p, 1, undef );
+    test_first_ede( $p, 1, undef );
 
     my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
 000084050001000000000001     # Header
@@ -163,11 +161,11 @@ subtest 'setting EDE multiple times only keeps one instance of EDE' => sub {
     $p->rcode('REFUSED');
 
     is(
-        exception { $p->ede($_) for 1..4 },
+        exception { $p->first_ede($_) for 1..4 },
         undef,
         'Setting plain EDE 4 times in a row doesn’t crash'
     );
-    test_ede( $p, 4, undef );
+    test_first_ede( $p, 4, undef );
 
     my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
 000084050001000000000001     # Header
@@ -191,11 +189,11 @@ subtest 'setting EDE with extra text' => sub {
     $p->rcode('REFUSED');
 
     is(
-        exception { $p->ede(13, 'AXFR failed: REFUSED') },
+        exception { $p->first_ede(13, 'AXFR failed: REFUSED') },
         undef,
         'Setting EDE with text doesn’t crash'
     );
-    test_ede( $p, 13, 'AXFR failed: REFUSED' );
+    test_first_ede( $p, 13, 'AXFR failed: REFUSED' );
 
     my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
 000084050001000000000001     # Header
@@ -223,11 +221,11 @@ subtest 'setting EDE with UTF-8 text' => sub {
     my $extra_text = '🐈';
 
     is(
-        exception { $p->ede(29, $extra_text) },
+        exception { $p->first_ede(29, $extra_text) },
         undef,
         'Setting EDE with UTF-8 text doesn’t crash'
     );
-    test_ede( $p, 29, $backup );
+    test_first_ede( $p, 29, $backup );
 
     is( $extra_text, $backup, 'Setting EDE has no ill side-effects on input variable' );
 
@@ -256,11 +254,11 @@ subtest 'setting EDE with null bytes in it' => sub {
     my $extra_text = "Messing\0with\0you\0";
 
     is(
-        exception { $p->ede(65530, $extra_text) },
+        exception { $p->first_ede(65530, $extra_text) },
         undef,
         'Setting EDE with embedded null bytes doesn’t crash'
     );
-    test_ede( $p, 65530, $extra_text );
+    test_first_ede( $p, 65530, $extra_text );
 
     my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
 000084050001000000000001     # Header

--- a/t/ede.t
+++ b/t/ede.t
@@ -5,10 +5,12 @@ use v5.16;
 use utf8;
 
 use open ':std', ':encoding(UTF-8)';
-use Test::More;
-use Test::Fatal qw(exception lives_ok);
+
+use Encode;
 use MIME::Base64;
 use Test::Differences;
+use Test::Fatal qw(exception lives_ok);
+use Test::More;
 
 BEGIN { use_ok( 'Zonemaster::LDNS' ) }
 
@@ -210,7 +212,41 @@ DATA
     );
 };
 
-subtest 'setting EDE with UTF-8 text' => sub {
+subtest 'setting EDE with UTF-8 Latin text' => sub {
+    my $p = Zonemaster::LDNS::Packet->new( 'test' );
+    $p->qr(1);
+    $p->aa(1);
+    $p->opcode('QUERY');
+    $p->rcode('REFUSED');
+
+    my $backup = 'français';
+    my $extra_text = 'français';
+
+    is(
+        exception { $p->first_ede(29, $extra_text) },
+        undef,
+        'Setting EDE with UTF-8 text doesn’t crash'
+    );
+    test_first_ede( $p, 29, $backup );
+
+    is( $extra_text, $backup, 'Setting EDE has no ill side-effects on input variable' );
+
+    my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
+000084050001000000000001     # Header
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 000f   # Additional section: OPT pseudo-RR
+000f 000b                    # EDNS option 15 (EDE) and length
+001d 6672616ec3a7616973      # EDE code 29 and text
+DATA
+
+    is(
+        unpack( 'H*', $p->wireformat() ),
+        $expected_wireformat,
+        'Packet contains only one instance of EDE'
+    );
+};
+
+subtest 'setting EDE with UTF-8 emoji text' => sub {
     my $p = Zonemaster::LDNS::Packet->new( 'test' );
     $p->qr(1);
     $p->aa(1);
@@ -266,6 +302,38 @@ subtest 'setting EDE with null bytes in it' => sub {
 00 0029 0000 00000000 0017   # Additional section: OPT pseudo-RR
 000f 0013                    # EDNS option 15 (EDE) and length
 fffa 4d657373696e67 00 77697468 00 796f75 00 # EDE code and string
+DATA
+
+    is(
+        unpack( 'H*', $p->wireformat() ),
+        $expected_wireformat,
+        'Packet’s wireformat is correct'
+    );
+};
+
+subtest 'setting EDE with invalid UTF-8 sequence in extra-text' => sub {
+    my $p = Zonemaster::LDNS::Packet->new( 'test' );
+
+    $p->qr(1);
+    $p->aa(1);
+    $p->opcode('QUERY');
+    $p->rcode('REFUSED');
+
+    my $extra_text = Encode::encode('iso-8859-1', "\x80\x81\x82\x83");
+
+    is(
+        exception { $p->first_ede(65530, $extra_text) },
+        undef,
+        'Setting EDE with embedded null bytes doesn’t crash'
+    );
+    test_first_ede( $p, 65530, $extra_text );
+
+    my $expected_wireformat = (<<DATA =~ s/ \s | \# [^\n]* \n //mgrx);
+000084050001000000000001     # Header
+04746573740000010001         # Question section: test./IN/A
+00 0029 0000 00000000 000a   # Additional section: OPT pseudo-RR
+000f 0006                    # EDNS option 15 (EDE) and length
+fffa 80818283                # EDE code and string
 DATA
 
     is(

--- a/t/rr.t
+++ b/t/rr.t
@@ -13,7 +13,7 @@ BEGIN { use_ok( 'Zonemaster::LDNS' ) }
 # order to save a packet in Base64 while showing its presentation format, just
 # run the following script:
 #
-# $ perl -MZonemaster::LDNS -MMIME::Base64
+# $ perl -MZonemaster::LDNS -MMIME::Base64 -Mfeature=say
 # my $p = Zonemaster::LDNS->new("86.54.11.100")->query("iis.se", "SOA");
 # say $p->string();
 # say encode_base64($p->wireformat());


### PR DESCRIPTION
## Purpose

This PR adds support for Extended DNS Errors (EDEs) in Zonemaster-LDNS, as specified in [RFC 8914](https://datatracker.ietf.org/doc/html/rfc8914).

In order to make AXFR packets cacheable in Zonemaster-Engine in a way that is compatible with the `axfr` API in Zonemaster-LDNS, the easiest option is to cache a synthetic (_i.e._ fake) packet. If the transfer fails for any reason, the code calls `croak` with a message and the synthetic packet has an RCODE of REFUSED instead of NOERROR.

But I wanted Zonemaster-Engine to `croak` with the same error message as the real AXFR message when replaying a cached AXFR response. Adding an EDE to the synthetic cached packet felt appropriate, with a code of 13 (Cached error) and an extra text consisting of the actual `croak` message.

This feature can also be useful later, should we want to examine EDEs in other situations.

## Context

Development of zonemaster/zonemaster-engine#938.

## Changes

 * Add a `first_ede()` method to Zonemaster::LDNS::Packet, acting as both a getter and a setter.

## How to test this PR

Unit tests were added and should pass.
