### PR TITLE
CI: Target Perl version 5.42

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false 
       matrix:
         perl:
-          - '5.40'
+          - '5.42'
           - '5.36'
           - '5.26'
         runner:


### PR DESCRIPTION
## Purpose

This PR updates the list of Perls tested against, replacing Perl 5.40 with Perl 5.42.

## Context

Recent release of Perl 5.42.2 (https://www.nntp.perl.org/group/perl.perl5.porters/2026/03/msg270839.html).

## Changes

 * Change Perl 5.40 to 5.42 in `.github/workflows/ci.yml`.

## How to test this PR

N/A.
