### PR TITLE
Dockerfile: add missing perl module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN apk add --no-cache \
     perl-mime-base32 \
     perl-module-install \
     perl-test-differences \
+    perl-test-exception \
     perl-test-fatal \
     perl-test-nowarnings \
-    perl-test-exception \
  && cpanm --notest --no-wget --from=https://cpan.metacpan.org/ \
     Module::Install::XSUtil
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apk add --no-cache \
     perl-test-differences \
     perl-test-fatal \
     perl-test-nowarnings \
+    perl-test-exception \
  && cpanm --notest --no-wget --from=https://cpan.metacpan.org/ \
     Module::Install::XSUtil
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22 as build
+FROM alpine:3.22 AS build
 
 RUN apk add --no-cache \
     # Compile-time dependencies


### PR DESCRIPTION
## Purpose

Add the missing `perl-test-exception` package to docker image.

## Context

The Docker image creation failed on a network where downloading the Perl package from http://www.cpan.org is blocked.

## Changes

- install `perl-test-exception` from alpine repositories.
- fix a warning "FromAsCasing"

## How to test this PR

`make docker-build` must work.
